### PR TITLE
Add support for anyOf composition keyword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ Types of changes are:
 * **Fixed** for any bug fixes.
 
 ## [Unreleased]
+### Added
+* `anyOf` composition keyword now supported.
+    - Creates models for each schema provided in the list.
+    - Generated models will instantiate the first compatible model,
+      based on the order they are presented.
 
 ## [0.1.1] - 2019-12-13
 ### Fixed

--- a/statham/constants.py
+++ b/statham/constants.py
@@ -1,4 +1,4 @@
-from enum import auto, Flag, unique
+from enum import auto, Enum, Flag, unique
 from functools import reduce
 from typing import Any, Dict, Iterator, List, Tuple, Union
 
@@ -100,3 +100,13 @@ _ENUM_LOOKUP = {enum: keyword for keyword, enum in _JSON_SCHEMA_TYPE_MAP}
 def get_type(flag: TypeEnum) -> Union[str, List[str]]:
     """Get jsonschema type representation of type flag."""
     return [_ENUM_LOOKUP[_flag] for _flag in _ENUM_LOOKUP if _flag & flag]
+
+
+@unique
+class CompositionTypeEnum(Enum):
+    ANY_OF = "anyOf"
+
+
+COMPOSITION_KEYWORDS = {
+    composition_type.value for composition_type in CompositionTypeEnum
+}

--- a/statham/constants.py
+++ b/statham/constants.py
@@ -45,6 +45,9 @@ IGNORED_SCHEMA_KEYWORDS = (
     "enum",
     "const",
     "uniqueItems",
+    "oneOf",
+    "allOf",
+    "not",
     # OpenAPI/Swagger
     "example",
     "nullable",

--- a/statham/converters.py
+++ b/statham/converters.py
@@ -40,9 +40,10 @@ def any_of_instantiate(*models: Type):
         if not isinstance(data, (dict, list)):
             return data
         for model in models:
-            instance = instantiate(model)(data)
-            if isinstance(data, model):
-                return instance
-        raise ValidationError(
-            None, None, data, f"Does not match any accepted model."
-        )
+            try:
+                return instantiate(model)(data)
+            except (TypeError, ValidationError):
+                continue
+        raise ValidationError.from_composition(models, data)
+
+    return _convert

--- a/statham/converters.py
+++ b/statham/converters.py
@@ -1,5 +1,6 @@
 from typing import Type
 
+from statham.exceptions import ValidationError
 from statham.validators import NotPassed
 
 
@@ -32,3 +33,16 @@ def map_instantiate(model: Type):
         return [_factory(data) for data in list_data]
 
     return _convert
+
+
+def any_of_instantiate(*models: Type):
+    def _convert(data):
+        if not isinstance(data, (dict, list)):
+            return data
+        for model in models:
+            instance = instantiate(model)(data)
+            if isinstance(data, model):
+                return instance
+        raise ValidationError(
+            None, None, data, f"Does not match any accepted model."
+        )

--- a/statham/dependency_resolver.py
+++ b/statham/dependency_resolver.py
@@ -1,9 +1,10 @@
-from typing import Dict, Set
+from itertools import chain
+from typing import Dict, List, Set
 
 from attr import attrs
 
 from statham.exceptions import SchemaParseError
-from statham.models import ArraySchema, ObjectSchema, Schema
+from statham.models import AnyOfSchema, ArraySchema, ObjectSchema, Schema
 
 
 # This is a dataclass.
@@ -14,12 +15,19 @@ class ClassDef:
     depends: Set[str]
 
 
-def _get_first_class_schema(schema: Schema) -> ObjectSchema:
+def _get_first_class_schemas(schema: Schema) -> List[ObjectSchema]:
     if isinstance(schema, ObjectSchema):
-        return schema
+        return [schema]
     if isinstance(schema, ArraySchema):
-        return _get_first_class_schema(schema.items)
-    raise SchemaParseError.no_class_equivalent_schemas()
+        return _get_first_class_schemas(schema.items)
+    if isinstance(schema, AnyOfSchema):
+        return list(
+            chain.from_iterable(
+                _get_first_class_schemas(sub_schema)
+                for sub_schema in schema.anyOf
+            )
+        )
+    return []
 
 
 class ClassDependencyResolver:
@@ -27,18 +35,18 @@ class ClassDependencyResolver:
 
     def __init__(self, schema: Schema):
         self._class_defs: Dict[str, ClassDef] = {}
-        _ = self._extract_schemas(_get_first_class_schema(schema))
+        for object_schema in _get_first_class_schemas(schema):
+            self._extract_schemas(object_schema)
 
     def _extract_schemas(self, schema: ObjectSchema) -> Set[str]:
         if schema.title in self._class_defs:
             return self[schema.title].depends
         deps = {schema.title}
         for nested in schema.properties.values():
-            try:
-                next_schema: ObjectSchema = _get_first_class_schema(nested)
-            except SchemaParseError:
-                continue
-            deps = deps | self._extract_schemas(next_schema)
+            next_schemas: List[ObjectSchema] = _get_first_class_schemas(nested)
+            deps = deps | set(
+                chain.from_iterable(map(self._extract_schemas, next_schemas))
+            )
         self._add(
             schema.title, ClassDef(schema=schema, depends=deps - {schema.title})
         )

--- a/statham/dependency_resolver.py
+++ b/statham/dependency_resolver.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Set
 from attr import attrs
 
 from statham.exceptions import SchemaParseError
-from statham.models import AnyOfSchema, ArraySchema, ObjectSchema, Schema
+from statham.models import ArraySchema, CompositionSchema, ObjectSchema, Schema
 
 
 # This is a dataclass.
@@ -20,11 +20,11 @@ def _get_first_class_schemas(schema: Schema) -> List[ObjectSchema]:
         return [schema]
     if isinstance(schema, ArraySchema):
         return _get_first_class_schemas(schema.items)
-    if isinstance(schema, AnyOfSchema):
+    if isinstance(schema, CompositionSchema):
         return list(
             chain.from_iterable(
                 _get_first_class_schemas(sub_schema)
-                for sub_schema in schema.anyOf
+                for sub_schema in schema.schemas
             )
         )
     return []

--- a/statham/exceptions.py
+++ b/statham/exceptions.py
@@ -11,10 +11,21 @@ class JSONSchemaObjectError(Exception):
 class ValidationError(JSONSchemaObjectError):
     """Validation failure in generated models."""
 
-    def __init__(self, instance, attribute, value, message) -> None:
-        super().__init__(
+    @classmethod
+    def from_validator(
+        cls, instance, attribute, value, message
+    ) -> "ValidationError":
+        return cls(
             f"Failed validating `{type(instance).__name__}."
             f"{attribute.name} = {repr(value)}`. {message}"
+        )
+
+    @classmethod
+    def from_composition(cls, models, data) -> "ValidationError":
+        return cls(
+            f"Does not match any accepted model.\n"
+            f"Data: {data}\n"
+            f"Models: {models}"
         )
 
 
@@ -23,7 +34,7 @@ class SchemaParseError(JSONSchemaObjectError):
 
     @classmethod
     def missing_type(cls, schema: Dict[str, JSONElement]) -> "SchemaParseError":
-        return cls(f"No type defined in schema: {schema}")
+        return cls(f"No type defined in schema: {json.dumps(schema, indent=2)}")
 
     @classmethod
     def unsupported_type_union(
@@ -54,5 +65,12 @@ class SchemaParseError(JSONSchemaObjectError):
     ) -> "SchemaParseError":
         return cls(
             "Failed to parse the following schema:\nError: "
-            f"{str(exception)}:\nSchema: {json.dumps(schema)}"
+            f"{str(exception)}:\nSchema: {json.dumps(schema, indent=2)}"
+        )
+
+    @classmethod
+    def invalid_composition_schema(cls, schema) -> "SchemaParseError":
+        return cls(
+            "Failed to parse schema with composition keyword(s):\n"
+            f"Schema: {json.dumps(schema, indent=2)}"
         )

--- a/statham/exceptions.py
+++ b/statham/exceptions.py
@@ -46,13 +46,6 @@ class SchemaParseError(JSONSchemaObjectError):
         )
 
     @classmethod
-    def no_class_equivalent_schemas(cls) -> "SchemaParseError":
-        return cls(
-            "Schema document contains no object schemas from which to "
-            "derive a class."
-        )
-
-    @classmethod
     def unresolvable_declaration(cls) -> "SchemaParseError":
         return cls(
             "Schema document has an unresolvable declaration tree. This "
@@ -71,6 +64,6 @@ class SchemaParseError(JSONSchemaObjectError):
     @classmethod
     def invalid_composition_schema(cls, schema) -> "SchemaParseError":
         return cls(
-            "Failed to parse schema with composition keyword(s):\n"
+            "Failed to parse schema with composition keyword:\n"
             f"Schema: {json.dumps(schema, indent=2)}"
         )

--- a/statham/models.py
+++ b/statham/models.py
@@ -54,7 +54,7 @@ def _list_schema_convert(array: List[Dict[str, JSONElement]]) -> List[Schema]:
 class CompositionSchema(Schema):
     @abstractproperty
     def schemas(self) -> List[Schema]:
-        ...
+        """List of schemas in the composition."""
 
 
 @attrs(kw_only=True, frozen=True)

--- a/statham/serializer.py
+++ b/statham/serializer.py
@@ -3,7 +3,7 @@ from typing import Iterable, List
 from jinja2 import Environment, FileSystemLoader
 
 from statham.constants import NOT_PROVIDED, TypeEnum
-from statham.models import ArraySchema, ObjectSchema, Schema
+from statham.models import AnyOfSchema, ArraySchema, ObjectSchema, Schema
 from statham.validators import (
     instance_of,
     NotPassed,
@@ -21,6 +21,18 @@ def default(schema: Schema, required: bool) -> str:
 
 
 def type_annotation(schema: Schema, required: bool) -> str:
+    if hasattr(schema, "type"):
+        annotations = standard_type_annotations(schema)
+    else:
+        annotations = composition_type_annotations(schema)
+    if not required:
+        annotations.append(NotPassed.__name__)
+    if len(annotations) == 1:
+        return next(iter(annotations))
+    return f"Union[{', '.join(annotations)}]"
+
+
+def standard_type_annotations(schema: Schema) -> List[str]:
     schema_items = getattr(schema, "items", NOT_PROVIDED)
     mapping = {
         TypeEnum.OBJECT: schema.title,
@@ -38,17 +50,26 @@ def type_annotation(schema: Schema, required: bool) -> str:
         TypeEnum.NULL: str(None),
         TypeEnum.BOOLEAN: bool.__name__,
     }
-    args = [arg for flag, arg in mapping.items() if flag & schema.type]
+    return [arg for flag, arg in mapping.items() if flag & schema.type]
 
-    if not required:
-        args.append(NotPassed.__name__)
-    if len(args) == 1:
-        return next(iter(args))
-    validator_args = ", ".join(args)
-    return f"Union[{validator_args}]"
+
+def composition_type_annotations(schema: Schema) -> List[str]:
+    if not isinstance(schema, AnyOfSchema):
+        raise Exception
+    return [type_annotation(sub_schema, True) for sub_schema in schema.anyOf]
 
 
 def validator_type_arg(schema: Schema) -> str:
+    if hasattr(schema, "type"):
+        args = standard_validator_type_args(schema)
+    else:
+        args = composition_validator_type_args(schema)
+    if len(args) == 1:
+        return next(iter(args))
+    return ", ".join(args)
+
+
+def standard_validator_type_args(schema: Schema):
     mapping = {
         TypeEnum.OBJECT: schema.title,
         TypeEnum.ARRAY: list.__name__,
@@ -58,10 +79,13 @@ def validator_type_arg(schema: Schema) -> str:
         TypeEnum.NULL: "type(None)",
         TypeEnum.BOOLEAN: bool.__name__,
     }
-    args = [arg for flag, arg in mapping.items() if flag & schema.type]
-    if len(args) == 1:
-        return next(iter(args))
-    return ", ".join(args)
+    return [arg for flag, arg in mapping.items() if flag & schema.type]
+
+
+def composition_validator_type_args(schema: Schema):
+    if not isinstance(schema, AnyOfSchema):
+        raise Exception
+    return [type_annotation(sub_schema, True) for sub_schema in schema.anyOf]
 
 
 INDENT = " " * 4
@@ -90,6 +114,16 @@ def converter(schema: Schema) -> str:
         schema.items, ObjectSchema
     ):
         return f"con.map_instantiate({schema.items.title})"
+    if isinstance(schema, AnyOfSchema):
+        types = ", ".join(
+            [
+                sub_schema.title
+                for sub_schema in schema.anyOf
+                if isinstance(sub_schema, ObjectSchema)
+            ]
+        )
+        if types:
+            return f"con.any_of_instantiate({types})"
     return ""
 
 

--- a/statham/serializer.py
+++ b/statham/serializer.py
@@ -28,10 +28,10 @@ def default(schema: Schema, required: bool) -> str:
 
 
 def type_annotation(schema: Schema, required: bool) -> str:
-    if hasattr(schema, "type"):
-        annotations = standard_type_annotations(schema)
-    else:
+    if isinstance(schema, CompositionSchema):
         annotations = composition_type_annotations(schema)
+    else:
+        annotations = standard_type_annotations(schema)
     if not required:
         annotations.append(NotPassed.__name__)
     if len(annotations) == 1:
@@ -60,17 +60,17 @@ def standard_type_annotations(schema: Schema) -> List[str]:
     return [arg for flag, arg in mapping.items() if flag & schema.type]
 
 
-def composition_type_annotations(schema: Schema) -> List[str]:
+def composition_type_annotations(schema: CompositionSchema) -> List[str]:
     if not isinstance(schema, AnyOfSchema):
-        raise Exception
+        raise NotImplementedError
     return [type_annotation(sub_schema, True) for sub_schema in schema.anyOf]
 
 
 def validator_type_arg(schema: Schema) -> str:
-    if hasattr(schema, "type"):
-        args = standard_validator_type_args(schema)
-    else:
+    if isinstance(schema, CompositionSchema):
         args = composition_validator_type_args(schema)
+    else:
+        args = standard_validator_type_args(schema)
     if len(args) == 1:
         return next(iter(args))
     return ", ".join(args)
@@ -89,9 +89,9 @@ def standard_validator_type_args(schema: Schema):
     return [arg for flag, arg in mapping.items() if flag & schema.type]
 
 
-def composition_validator_type_args(schema: Schema):
+def composition_validator_type_args(schema: CompositionSchema):
     if not isinstance(schema, AnyOfSchema):
-        raise Exception
+        raise NotImplementedError
     return [type_annotation(sub_schema, True) for sub_schema in schema.anyOf]
 
 

--- a/statham/serializer.py
+++ b/statham/serializer.py
@@ -4,7 +4,13 @@ from typing import Iterable, List
 from jinja2 import Environment, FileSystemLoader
 
 from statham.constants import NOT_PROVIDED, TypeEnum
-from statham.models import AnyOfSchema, ArraySchema, ObjectSchema, Schema
+from statham.models import (
+    AnyOfSchema,
+    ArraySchema,
+    CompositionSchema,
+    ObjectSchema,
+    Schema,
+)
 from statham.validators import (
     instance_of,
     NotPassed,
@@ -100,7 +106,7 @@ def validators(schema: Schema) -> str:
 
 
 def extra_validators(schema: Schema) -> List[str]:
-    if hasattr(schema, "schemas"):
+    if isinstance(schema, CompositionSchema):
         return list(
             chain.from_iterable(
                 extra_validators(sub_schema) for sub_schema in schema.schemas

--- a/statham/serializer.py
+++ b/statham/serializer.py
@@ -1,3 +1,4 @@
+from itertools import chain
 from typing import Iterable, List
 
 from jinja2 import Environment, FileSystemLoader
@@ -99,6 +100,12 @@ def validators(schema: Schema) -> str:
 
 
 def extra_validators(schema: Schema) -> List[str]:
+    if hasattr(schema, "schemas"):
+        return list(
+            chain.from_iterable(
+                extra_validators(sub_schema) for sub_schema in schema.schemas
+            )
+        )
     return [
         (f"val.{validator.__name__}({repr(getattr(schema, attribute))}),")
         for attribute, validator in SCHEMA_ATTRIBUTE_VALIDATORS.items()

--- a/statham/validators.py
+++ b/statham/validators.py
@@ -101,7 +101,13 @@ def raises(message: str) -> Callable:
                 instance,
                 attribute,
                 value,
-                partial(ValidationError, instance, attribute, value, message),
+                partial(
+                    ValidationError.from_validator,
+                    instance,
+                    attribute,
+                    value,
+                    message,
+                ),
             )
 
         return inner_validator

--- a/tests/composition/test_any_of.py
+++ b/tests/composition/test_any_of.py
@@ -74,7 +74,6 @@ class TestObjectAnyOf:
         assert "Does not match any accepted model." in str(excinfo.value)
 
 
-@pytest.mark.foo
 class TestMixedAnyOf:
     @staticmethod
     def test_mixed_schema_accepts_primitive_string():

--- a/tests/composition/test_any_of.py
+++ b/tests/composition/test_any_of.py
@@ -1,0 +1,59 @@
+import pytest
+
+from statham.exceptions import ValidationError
+from tests.models.any_of import FooStringMinLength, BarIntegerFooString, Model
+
+
+class TestPrimitiveAnyOf:
+    @staticmethod
+    def test_model_instantiates_with_no_args():
+        assert Model()
+
+    @staticmethod
+    def test_primitive_any_of_accepts_string_type():
+        assert Model(primitive="foo").primitive == "foo"
+
+    @staticmethod
+    def test_primitive_any_of_accepts_integer_type():
+        assert Model(primitive=3).primitive == 3
+
+    @staticmethod
+    def test_primitive_any_of_rejects_other_type():
+        with pytest.raises(ValidationError):
+            Model(primitive={"foo": "bar"})
+
+    @staticmethod
+    def test_primitive_validation_is_applied_to_string_type():
+        with pytest.raises(ValidationError):
+            Model(primitive="fo")
+
+    @staticmethod
+    def test_primitive_validation_is_applied_to_integer_type():
+        with pytest.raises(ValidationError):
+            Model(primitive=1)
+
+
+class TestObjectAnyOf:
+    @staticmethod
+    def test_input_matching_only_first_schema_resolves_to_that_type():
+        instance = Model(objects={"foo": "barbaz"})
+        assert isinstance(instance.objects, FooStringMinLength)
+        assert instance.objects.foo == "barbaz"
+
+    @staticmethod
+    def test_input_matching_only_second_schema_resolves_to_that_type():
+        instance = Model(objects={"bar": 1, "foo": 2})
+        assert isinstance(instance.objects, BarIntegerFooString)
+        assert instance.objects.bar == 1
+
+    @staticmethod
+    def test_input_matching_both_schemas_resolves_to_first_type():
+        instance = Model(objects={"foo": "bar"})
+        assert isinstance(instance.objects, FooStringMinLength)
+        assert instance.objects.foo == "bar"
+
+    @staticmethod
+    def test_input_matching_neither_schemas_raises_validation_error():
+        with pytest.raises(ValidationError) as excinfo:
+            Model(objects={"foo": "barbaz", "bar": 1})
+        assert "Does not match any accepted model." in str(excinfo.value)

--- a/tests/composition/test_any_of.py
+++ b/tests/composition/test_any_of.py
@@ -3,7 +3,12 @@ from typing import Optional
 import pytest
 
 from statham.exceptions import ValidationError
-from tests.models.any_of import StringWrapper, StringAndIntegerWrapper, Model
+from tests.models.any_of import (
+    Model,
+    OtherStringWrapper,
+    StringWrapper,
+    StringAndIntegerWrapper,
+)
 
 
 class TestPrimitiveAnyOf:
@@ -67,3 +72,27 @@ class TestObjectAnyOf:
         with pytest.raises(ValidationError) as excinfo:
             Model(objects={"string_prop": "barbaz", "integer_prop": 1})
         assert "Does not match any accepted model." in str(excinfo.value)
+
+
+@pytest.mark.foo
+class TestMixedAnyOf:
+    @staticmethod
+    def test_mixed_schema_accepts_primitive_string():
+        instance = Model(mixed="foo")
+        assert instance.mixed == "foo"
+
+    @staticmethod
+    def test_mixed_schema_accepts_string_wrapper():
+        instance = Model(mixed={"string_prop": "foo"})
+        assert isinstance(instance.mixed, OtherStringWrapper)
+        assert instance.mixed.string_prop == "foo"
+
+    @staticmethod
+    def test_bad_primitive_raises_validation_error():
+        with pytest.raises(ValidationError):
+            _ = Model(mixed=1)
+
+    @staticmethod
+    def test_bad_object_raises_validation_error():
+        with pytest.raises(ValidationError):
+            _ = Model(mixed={"string_prop": 1})

--- a/tests/composition/test_any_of.py
+++ b/tests/composition/test_any_of.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import pytest
 
 from statham.exceptions import ValidationError
@@ -41,8 +43,14 @@ class TestObjectAnyOf:
         assert instance.objects.foo == "barbaz"
 
     @staticmethod
-    def test_input_matching_only_second_schema_resolves_to_that_type():
-        instance = Model(objects={"bar": 1, "foo": 2})
+    @pytest.mark.parametrize("foo", [None, "fo", "foo"])
+    def test_input_matching_only_second_schema_resolves_to_that_type(
+        foo: Optional[str]
+    ):
+        if not foo:
+            instance = Model(objects={"bar": 1})
+        else:
+            instance = Model(objects={"bar": 1, "foo": foo})
         assert isinstance(instance.objects, BarIntegerFooString)
         assert instance.objects.bar == 1
 

--- a/tests/composition/test_any_of.py
+++ b/tests/composition/test_any_of.py
@@ -3,7 +3,7 @@ from typing import Optional
 import pytest
 
 from statham.exceptions import ValidationError
-from tests.models.any_of import FooStringMinLength, BarIntegerFooString, Model
+from tests.models.any_of import StringWrapper, StringAndIntegerWrapper, Model
 
 
 class TestPrimitiveAnyOf:
@@ -38,30 +38,32 @@ class TestPrimitiveAnyOf:
 class TestObjectAnyOf:
     @staticmethod
     def test_input_matching_only_first_schema_resolves_to_that_type():
-        instance = Model(objects={"foo": "barbaz"})
-        assert isinstance(instance.objects, FooStringMinLength)
-        assert instance.objects.foo == "barbaz"
+        instance = Model(objects={"string_prop": "barbaz"})
+        assert isinstance(instance.objects, StringWrapper)
+        assert instance.objects.string_prop == "barbaz"
 
     @staticmethod
-    @pytest.mark.parametrize("foo", [None, "fo", "foo"])
+    @pytest.mark.parametrize("string_prop", [None, "fo", "foo"])
     def test_input_matching_only_second_schema_resolves_to_that_type(
-        foo: Optional[str]
+        string_prop: Optional[str]
     ):
-        if not foo:
-            instance = Model(objects={"bar": 1})
+        if not string_prop:
+            instance = Model(objects={"integer_prop": 1})
         else:
-            instance = Model(objects={"bar": 1, "foo": foo})
-        assert isinstance(instance.objects, BarIntegerFooString)
-        assert instance.objects.bar == 1
+            instance = Model(
+                objects={"integer_prop": 1, "string_prop": string_prop}
+            )
+        assert isinstance(instance.objects, StringAndIntegerWrapper)
+        assert instance.objects.integer_prop == 1
 
     @staticmethod
     def test_input_matching_both_schemas_resolves_to_first_type():
-        instance = Model(objects={"foo": "bar"})
-        assert isinstance(instance.objects, FooStringMinLength)
-        assert instance.objects.foo == "bar"
+        instance = Model(objects={"string_prop": "bar"})
+        assert isinstance(instance.objects, StringWrapper)
+        assert instance.objects.string_prop == "bar"
 
     @staticmethod
     def test_input_matching_neither_schemas_raises_validation_error():
         with pytest.raises(ValidationError) as excinfo:
-            Model(objects={"foo": "barbaz", "bar": 1})
+            Model(objects={"string_prop": "barbaz", "integer_prop": 1})
         assert "Does not match any accepted model." in str(excinfo.value)

--- a/tests/jsonschemas/any_of.json
+++ b/tests/jsonschemas/any_of.json
@@ -18,12 +18,12 @@
       "anyOf": [
         {
           "type": "object",
-          "title": "FooStringMinLength",
+          "title": "StringWrapper",
           "required": [
-            "foo"
+            "string_prop"
           ],
           "properties": {
-            "foo": {
+            "string_prop": {
               "type": "string",
               "minLength": 3
             }
@@ -31,16 +31,16 @@
         },
         {
           "type": "object",
-          "title": "BarIntegerFooString",
+          "title": "StringAndIntegerWrapper",
           "required": [
-            "bar"
+            "integer_prop"
           ],
           "properties": {
-            "foo": {
+            "string_prop": {
               "type": "string",
               "maxLength": 5
             },
-            "bar": {
+            "integer_prop": {
               "type": "integer"
             }
           }
@@ -51,9 +51,9 @@
       "anyOf": [
         {
           "type": "object",
-          "title": "FooString",
+          "title": "OtherStringWrapper",
           "properties": {
-            "foo": {
+            "string_prop": {
               "type": "string"
             }
           }

--- a/tests/jsonschemas/any_of.json
+++ b/tests/jsonschemas/any_of.json
@@ -1,0 +1,67 @@
+{
+  "title": "Model",
+  "type": "object",
+  "properties": {
+    "primitive": {
+      "anyOf": [
+        {
+          "type": "string",
+          "minLength": 3
+        },
+        {
+          "type": "integer",
+          "minimum": 3
+        }
+      ]
+    },
+    "objects": {
+      "anyOf": [
+        {
+          "type": "object",
+          "title": "FooStringMinLength",
+          "required": [
+            "foo"
+          ],
+          "properties": {
+            "foo": {
+              "type": "string",
+              "minLength": 3
+            }
+          }
+        },
+        {
+          "type": "object",
+          "title": "BarIntegerFooString",
+          "required": [
+            "bar"
+          ],
+          "properties": {
+            "foo": {
+              "type": "string",
+              "maxLength": 5
+            },
+            "bar": {
+              "type": "integer"
+            }
+          }
+        }
+      ]
+    },
+    "mixed": {
+      "anyOf": [
+        {
+          "type": "object",
+          "title": "FooString",
+          "properties": {
+            "foo": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    }
+  }
+}

--- a/tests/models/any_of.py
+++ b/tests/models/any_of.py
@@ -53,9 +53,9 @@ class Model:
     )
     objects: Union[FooStringMinLength, BarIntegerFooString, NotPassed] = attrib(
         validator=[val.instance_of(FooStringMinLength, BarIntegerFooString)],
-        converter=con.any_of_instantiate(
+        converter=con.any_of_instantiate(  # type: ignore
             FooStringMinLength, BarIntegerFooString
-        ),  # type: ignore
+        ),
         default=NotPassed(),
     )
     mixed: Union[FooString, str, NotPassed] = attrib(

--- a/tests/models/any_of.py
+++ b/tests/models/any_of.py
@@ -44,7 +44,12 @@ class Model:
     _required: ClassVar[List[str]] = []
 
     primitive: Union[str, int, NotPassed] = attrib(
-        validator=[val.instance_of(str, int)], default=NotPassed()
+        validator=[
+            val.instance_of(str, int),
+            val.min_length(3),
+            val.minimum(3),
+        ],
+        default=NotPassed(),
     )
     objects: Union[FooStringMinLength, BarIntegerFooString, NotPassed] = attrib(
         validator=[val.instance_of(FooStringMinLength, BarIntegerFooString)],

--- a/tests/models/any_of.py
+++ b/tests/models/any_of.py
@@ -6,33 +6,35 @@ from statham.validators import NotPassed
 
 
 @attrs(kw_only=True)
-class FooStringMinLength:
-    """FooStringMinLength"""
+class StringWrapper:
+    """StringWrapper"""
 
-    _required: ClassVar[List[str]] = ["foo"]
+    _required: ClassVar[List[str]] = ["string_prop"]
 
-    foo: str = attrib(validator=[val.instance_of(str), val.min_length(3)])
+    string_prop: str = attrib(
+        validator=[val.instance_of(str), val.min_length(3)]
+    )
 
 
 @attrs(kw_only=True)
-class BarIntegerFooString:
-    """BarIntegerFooString"""
+class StringAndIntegerWrapper:
+    """StringAndIntegerWrapper"""
 
-    _required: ClassVar[List[str]] = ["bar"]
+    _required: ClassVar[List[str]] = ["integer_prop"]
 
-    foo: Union[str, NotPassed] = attrib(
+    string_prop: Union[str, NotPassed] = attrib(
         validator=[val.instance_of(str), val.max_length(5)], default=NotPassed()
     )
-    bar: int = attrib(validator=[val.instance_of(int)])
+    integer_prop: int = attrib(validator=[val.instance_of(int)])
 
 
 @attrs(kw_only=True)
-class FooString:
-    """FooString"""
+class OtherStringWrapper:
+    """OtherStringWrapper"""
 
     _required: ClassVar[List[str]] = []
 
-    foo: Union[str, NotPassed] = attrib(
+    string_prop: Union[str, NotPassed] = attrib(
         validator=[val.instance_of(str)], default=NotPassed()
     )
 
@@ -51,15 +53,15 @@ class Model:
         ],
         default=NotPassed(),
     )
-    objects: Union[FooStringMinLength, BarIntegerFooString, NotPassed] = attrib(
-        validator=[val.instance_of(FooStringMinLength, BarIntegerFooString)],
+    objects: Union[StringWrapper, StringAndIntegerWrapper, NotPassed] = attrib(
+        validator=[val.instance_of(StringWrapper, StringAndIntegerWrapper)],
         converter=con.any_of_instantiate(  # type: ignore
-            FooStringMinLength, BarIntegerFooString
+            StringWrapper, StringAndIntegerWrapper
         ),
         default=NotPassed(),
     )
-    mixed: Union[FooString, str, NotPassed] = attrib(
-        validator=[val.instance_of(FooString, str)],
-        converter=con.any_of_instantiate(FooString),  # type: ignore
+    mixed: Union[OtherStringWrapper, str, NotPassed] = attrib(
+        validator=[val.instance_of(OtherStringWrapper, str)],
+        converter=con.any_of_instantiate(OtherStringWrapper),  # type: ignore
         default=NotPassed(),
     )

--- a/tests/models/any_of.py
+++ b/tests/models/any_of.py
@@ -1,0 +1,60 @@
+from typing import ClassVar, List, Union
+
+from attr import attrs, attrib
+from statham import converters as con, validators as val
+from statham.validators import NotPassed
+
+
+@attrs(kw_only=True)
+class FooStringMinLength:
+    """FooStringMinLength"""
+
+    _required: ClassVar[List[str]] = ["foo"]
+
+    foo: str = attrib(validator=[val.instance_of(str), val.min_length(3)])
+
+
+@attrs(kw_only=True)
+class BarIntegerFooString:
+    """BarIntegerFooString"""
+
+    _required: ClassVar[List[str]] = ["bar"]
+
+    foo: Union[str, NotPassed] = attrib(
+        validator=[val.instance_of(str), val.max_length(5)], default=NotPassed()
+    )
+    bar: int = attrib(validator=[val.instance_of(int)])
+
+
+@attrs(kw_only=True)
+class FooString:
+    """FooString"""
+
+    _required: ClassVar[List[str]] = []
+
+    foo: Union[str, NotPassed] = attrib(
+        validator=[val.instance_of(str)], default=NotPassed()
+    )
+
+
+@attrs(kw_only=True)
+class Model:
+    """Model"""
+
+    _required: ClassVar[List[str]] = []
+
+    primitive: Union[str, int, NotPassed] = attrib(
+        validator=[val.instance_of(str, int)], default=NotPassed()
+    )
+    objects: Union[FooStringMinLength, BarIntegerFooString, NotPassed] = attrib(
+        validator=[val.instance_of(FooStringMinLength, BarIntegerFooString)],
+        converter=con.any_of_instantiate(
+            FooStringMinLength, BarIntegerFooString
+        ),  # type: ignore
+        default=NotPassed(),
+    )
+    mixed: Union[FooString, str, NotPassed] = attrib(
+        validator=[val.instance_of(FooString, str)],
+        converter=con.any_of_instantiate(FooString),  # type: ignore
+        default=NotPassed(),
+    )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -148,3 +148,17 @@ def test_parse_schema_without_type():
 def test_union_model_fails_for_invalid_types():
     with pytest.raises(SchemaParseError):
         _union_model(ObjectSchema, ArraySchema)
+
+
+def test_parse_schema_fails_with_unknown_properties():
+    with pytest.raises(SchemaParseError) as excinfo:
+        parse_schema({"type": "string", "foo": "bar"})
+    assert "Failed to parse the following schema" in str(excinfo.value)
+
+
+def test_parse_schema_fails_for_bad_composition_schema():
+    with pytest.raises(SchemaParseError) as excinfo:
+        parse_schema({"anyOf": [{"type": "string"}], "foo": "bar"})
+    assert "Failed to parse schema with composition keyword" in str(
+        excinfo.value
+    )


### PR DESCRIPTION
Any related Github Issues?: #13  

### Added
* `anyOf` composition keyword now supported.
    - Creates models for each schema provided in the list.
    - Generated models will instantiate the first compatible model,
      based on the order they are presented.

# Check list

## Before asking for a review

- [x] Target branch is `master`
- [x] `make test` passes locally.
- [x] [`[Unreleased]`](../blob/master/CHANGELOG.md#unreleased) section in [CHANGELOG.md](../blob/master/CHANGELOG.md) is updated.
- [x] I reviewed the "Files changed" tab and self-annotated anything unexpected.

## Before review (reviewer)

- [ ] All of the above are checked and true. **Review ALL items.** If not, return the PR to the author.
- [ ] Continuous Integration is passing. If not, return the PR to the author.

## After merge (reviewer)

- [ ] Any issues that may now be closed are closed.