### PR TITLE
Feature/allow properties named self

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Types of changes are:
 ## [Unreleased]
 ### Added
 * Added support for `default` as a property name in object schemas.
+* Added support for `self` as a property name in object schemas.
 
 ## [0.2.0] - 2020-03-20
 ### Added

--- a/statham/dsl/parser.py
+++ b/statham/dsl/parser.py
@@ -164,7 +164,9 @@ def _new_object(
         # Ignore malformed values.
         if isinstance(value, dict)
     }
-    class_dict = ObjectClassDict(default=default, **properties)
+    class_dict = ObjectClassDict(default=default)
+    for key, value in properties.items():
+        class_dict[key] = value
     return ObjectMeta(_title_format(title), (Object,), class_dict)
 
 

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -17,7 +17,6 @@ SCHEMA = {
             "default": {"value": "none"},
         },
         "default": {"type": "string"},
-        "self": {"type": "string"},
     },
     "definitions": {
         "other": {
@@ -62,12 +61,42 @@ class Parent(Object):
 
     _default: Maybe[str] = Property(String(), name='default')
 
-    self: Maybe[str] = Property(String())
-
 
 class Other(Object):
 
     value: Maybe[int] = Property(Integer())
+"""
+    )
+
+
+def test_parse_and_serialize_schema_with_self_property():
+    schema = {
+        "type": "object",
+        "title": "MyObject",
+        "properties": {"self": {"type": "string"}},
+    }
+    assert (
+        serialize_python(*parse(schema))
+        == """from typing import List, Union
+
+from statham.dsl.constants import Maybe
+from statham.dsl.elements import (
+    AnyOf,
+    Array,
+    Boolean,
+    Integer,
+    Null,
+    Number,
+    OneOf,
+    Object,
+    String,
+)
+from statham.dsl.property import Property
+
+
+class MyObject(Object):
+
+    self: Maybe[str] = Property(String())
 """
     )
 

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -17,6 +17,7 @@ SCHEMA = {
             "default": {"value": "none"},
         },
         "default": {"type": "string"},
+        "self": {"type": "string"},
     },
     "definitions": {
         "other": {
@@ -60,6 +61,8 @@ class Parent(Object):
     category: Category = Property(Category, required=True)
 
     _default: Maybe[str] = Property(String(), name='default')
+
+    self: Maybe[str] = Property(String())
 
 
 class Other(Object):


### PR DESCRIPTION
* Added support for `self` as a property name in object schemas.

# Check list

## Before asking for a review

- [x] Target branch is `master`
- [x] `make test` passes locally.
- [x] [`[Unreleased]`](../blob/master/CHANGELOG.md#unreleased) section in [CHANGELOG.md](../blob/master/CHANGELOG.md) is updated.
- [x] I reviewed the "Files changed" tab and self-annotated anything unexpected.

## Before review (reviewer)

- [ ] All of the above are checked and true. **Review ALL items.** If not, return the PR to the author.
- [ ] Continuous Integration is passing. If not, return the PR to the author.

## After merge (reviewer)

- [ ] Any issues that may now be closed are closed.