### PR TITLE
Move bulk of serialization logic to dsl elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Types of changes are:
 * Added support for `default` as a property name in object schemas.
 * Added support for `self` as a property name in object schemas.
 
+### Changed
+* Moved bulk to python serialization logic to DSL element methods.
+
 ## [0.2.0] - 2020-03-20
 ### Added
 * A JSONSchema DSL (see `statham/dsl/`) has been added, and is

--- a/statham/dsl/elements/base.py
+++ b/statham/dsl/elements/base.py
@@ -41,6 +41,9 @@ class Element(Generic[T]):
     def annotation(self) -> str:
         return "Any"
 
+    def python(self) -> str:
+        return repr(self)
+
     @property
     def type_validator(self):
         return lambda _, __: None

--- a/statham/dsl/property.py
+++ b/statham/dsl/property.py
@@ -83,6 +83,14 @@ class _Property(Generic[PropType]):
             return self.element.annotation
         return f"Maybe[{self.element.annotation}]"
 
+    def python(self) -> str:
+        prop_def = repr(self).replace(type(self).__name__, Property.__name__)
+        return (
+            (f"{self.bound_name}: {self.annotation} = {prop_def}")
+            if self.bound_name
+            else prop_def
+        )
+
 
 UNBOUND_PROPERTY: _Property = _Property(
     Element(), required=False, name="<unbound>"

--- a/statham/dsl/property.pyi
+++ b/statham/dsl/property.pyi
@@ -38,6 +38,9 @@ class _Property(Generic[PropType]):
     def annotation(self) -> str:
         ...
 
+    def python(self) -> str:
+        ...
+
     def __call__(self, value: Any) -> Maybe[PropType]:
         ...
 

--- a/statham/serializer.py
+++ b/statham/serializer.py
@@ -1,7 +1,4 @@
-from statham.dsl.constants import NotPassed
 from statham.dsl.elements import Element
-from statham.dsl.elements.meta import ObjectMeta
-from statham.dsl.property import _Property, Property
 from statham.orderer import Orderer
 
 
@@ -33,44 +30,5 @@ def serialize_python(*elements: Element) -> str:
     elements this depends on.
     """
     return _IMPORT_STATEMENTS + "\n\n".join(
-        [_serialize_object(object_model) for object_model in Orderer(*elements)]
-    )
-
-
-def _serialize_object(object_cls: ObjectMeta) -> str:
-    super_cls = next(iter(object_cls.mro()[1:]))
-    cls_args = (
-        f"metaclass={type(object_cls).__name__}"
-        if super_cls is object
-        else super_cls.__name__
-    )
-    class_def = f"""class {repr(object_cls)}({cls_args}):
-"""
-    if not object_cls.properties and isinstance(object_cls.default, NotPassed):
-        class_def = (
-            class_def
-            + """
-    pass
-"""
-        )
-    if not isinstance(object_cls.default, NotPassed):
-        class_def = (
-            class_def
-            + f"""
-    default = {repr(object_cls.default)}
-"""
-        )
-    for property_ in object_cls.properties.values():
-        class_def = (
-            class_def
-            + f"""
-    {property_.bound_name}: {property_.annotation} = {_serialize_property(property_)}
-"""
-        )
-    return class_def
-
-
-def _serialize_property(property_: _Property) -> str:
-    return repr(property_).replace(
-        property_.__class__.__name__, Property.__name__
+        [object_model.python() for object_model in Orderer(*elements)]
     )


### PR DESCRIPTION
### Changed
* Moved bulk to python serialization logic to DSL element methods.

# Check list

## Before asking for a review

- [x] Target branch is `master`
- [x] `make test` passes locally.
- [x] [`[Unreleased]`](../blob/master/CHANGELOG.md#unreleased) section in [CHANGELOG.md](../blob/master/CHANGELOG.md) is updated.
- [x] I reviewed the "Files changed" tab and self-annotated anything unexpected.

## Before review (reviewer)

- [ ] All of the above are checked and true. **Review ALL items.** If not, return the PR to the author.
- [ ] Continuous Integration is passing. If not, return the PR to the author.

## After merge (reviewer)

- [ ] Any issues that may now be closed are closed.