### PR TITLE
Feature/allow untyped validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,13 @@ Types of changes are:
 
 ## [Unreleased]
 ### Added
-* Added `source` keyword argument to `Property`. This allows mapping of input
-  properties to differeing model attribute names.
+* Added `source` keyword argument to `Property`. This allows mapping
+  of input properties to differeing model attribute names.
 * Added support for `additionalProperties` keyword argument.
 * Added support for `default` as a property name in object schemas.
 * Added support for `self` as a property name in object schemas.
+* Added support for `default` and validation keywords in un-typed
+  schemas.
 
 ### Changed
 * Moved bulk of python serialization logic to DSL element methods.

--- a/statham/dsl/elements/array.py
+++ b/statham/dsl/elements/array.py
@@ -44,15 +44,6 @@ class Array(Element[List[Item]]):
     def type_validator(self):
         return val.instance_of(list)
 
-    @property
-    def validators(self):
-        validators = super().validators
-        if not isinstance(self.minItems, NotPassed):
-            validators.append(val.min_items(self.minItems))
-        if not isinstance(self.maxItems, NotPassed):
-            validators.append(val.max_items(self.maxItems))
-        return validators
-
     def construct(self, value, property_):
         return [
             self.items(item, property_.evolve(property_.name + f"[{idx}]"))

--- a/statham/dsl/elements/base.py
+++ b/statham/dsl/elements/base.py
@@ -21,7 +21,6 @@ class Element(Generic[T]):
     type when called.
     # TODO: enum
     # TODO: const
-    # TODO: type-specific keywords don't apply to element.
     """
 
     def __init__(

--- a/statham/dsl/elements/base.py
+++ b/statham/dsl/elements/base.py
@@ -24,14 +24,12 @@ class Element(Generic[T]):
     # TODO: type-specific keywords don't apply to element.
     """
 
-    default: Any = NotPassed()
-
     def __init__(
         self,
         *,
         # Bad name to match JSONSchema keywords.
         # pylint: disable=invalid-name
-        default: Maybe[str] = NotPassed(),
+        default: Maybe[Any] = NotPassed(),
         minItems: Maybe[int] = NotPassed(),
         maxItems: Maybe[int] = NotPassed(),
         minimum: Maybe[Numeric] = NotPassed(),

--- a/statham/dsl/elements/numeric.py
+++ b/statham/dsl/elements/numeric.py
@@ -1,4 +1,4 @@
-from typing import List, TypeVar, Union
+from typing import TypeVar, Union
 
 from statham.dsl import validators as val
 from statham.dsl.elements.base import Element
@@ -36,21 +36,6 @@ class NumericElement(Element[T]):
         self.exclusiveMinimum = exclusiveMinimum
         self.exclusiveMaximum = exclusiveMaximum
         self.multipleOf = multipleOf
-
-    @property
-    def validators(self):
-        validators: List[val.Validator] = super().validators
-        if not isinstance(self.minimum, NotPassed):
-            validators.append(val.minimum(self.minimum))
-        if not isinstance(self.maximum, NotPassed):
-            validators.append(val.maximum(self.maximum))
-        if not isinstance(self.exclusiveMinimum, NotPassed):
-            validators.append(val.exclusive_minimum(self.exclusiveMinimum))
-        if not isinstance(self.exclusiveMaximum, NotPassed):
-            validators.append(val.exclusive_maximum(self.exclusiveMaximum))
-        if not isinstance(self.multipleOf, NotPassed):
-            validators.append(val.multiple_of(self.multipleOf))
-        return validators
 
 
 class Integer(NumericElement[int]):

--- a/statham/dsl/elements/string.py
+++ b/statham/dsl/elements/string.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from statham.dsl import validators as val
 from statham.dsl.elements.base import Element
 from statham.dsl.constants import Maybe, NotPassed
@@ -40,16 +38,3 @@ class String(Element[str]):
     @property
     def type_validator(self):
         return val.instance_of(str)
-
-    @property
-    def validators(self):
-        validators: List[val.Validator] = super().validators
-        if not isinstance(self.format, NotPassed):
-            validators.append(val.has_format(self.format))
-        if not isinstance(self.pattern, NotPassed):
-            validators.append(val.pattern(self.pattern))
-        if not isinstance(self.minLength, NotPassed):
-            validators.append(val.min_length(self.minLength))
-        if not isinstance(self.maxLength, NotPassed):
-            validators.append(val.max_length(self.maxLength))
-        return validators

--- a/statham/dsl/parser.py
+++ b/statham/dsl/parser.py
@@ -94,7 +94,7 @@ def parse_element(
     if {"anyOf", "oneOf"} & set(schema):
         return parse_composition(schema, counter)
     if "type" not in schema:
-        return Element()
+        return Element(**keyword_filter(Element)(schema))
     return parse_typed(schema["type"], schema, counter)
 
 

--- a/statham/dsl/validators.py
+++ b/statham/dsl/validators.py
@@ -74,6 +74,18 @@ def _is_date_time(value: str) -> bool:
 Validator = Callable[[Any, Any], None]
 
 
+def _is_instance(value, type_args):
+    """Variant of isinstance to handle booleans correctly.
+
+    In CPython, isinstance(True, int) evaluates True.
+    """
+    if isinstance(value, bool):
+        if bool in type_args:
+            return True
+        return False
+    return isinstance(value, type_args)
+
+
 def on_types(*type_args: Type) -> Callable[[Validator], Validator]:
     """Decorator factory to limit scope of validators to given types."""
 
@@ -81,7 +93,7 @@ def on_types(*type_args: Type) -> Callable[[Validator], Validator]:
         """Return a wrapped version of `validator` to negotiate type."""
 
         def _inner_validator(value, property_) -> None:
-            if not isinstance(value, type_args):
+            if not _is_instance(value, type_args):
                 return
             validator(value, property_)
 

--- a/tests/dsl/elements/test_element.py
+++ b/tests/dsl/elements/test_element.py
@@ -1,0 +1,56 @@
+from typing import Any, Iterator, List, NamedTuple, Tuple
+import pytest
+
+from statham.dsl.constants import NotPassed
+from statham.dsl.elements import Element
+from statham.dsl.exceptions import ValidationError
+from tests.helpers import no_raise
+
+
+class Case(NamedTuple):
+    element: Element
+    good: List[Any]
+    bad: List[Any]
+
+
+CASES = [
+    Case(
+        element=Element(),
+        good=[None, NotPassed(), True, 1, 1.2, "foo", {}, ["foo", 1]],
+        bad=[],
+    ),
+    Case(
+        element=Element(minItems=3),
+        good=[None, NotPassed(), True, 1, 1.2, "foo", {}, ["foo", 1, 5]],
+        bad=[[], [1, 2]],
+    ),
+    Case(
+        element=Element(minimum=3),
+        good=[None, NotPassed(), True, 3, 4.2, "foo", {}, ["foo", 1]],
+        bad=[2, 2.1],
+    ),
+    Case(
+        element=Element(minLength=3),
+        good=[None, NotPassed(), True, 1, 1.2, "foo", {}, ["foo", 1]],
+        bad=["ab", ""],
+    ),
+    Case(
+        element=Element(minItems=3, minimum=3, minLength=3),
+        good=[None, NotPassed(), True, 3, 4.2, "foo", {}, ["foo", 1, 5]],
+        bad=[[], [1, 2], 2, 2.1, "ab", ""],
+    ),
+]
+
+
+def to_test_params(cases: List[Case]) -> Iterator[Tuple[Element, Any, bool]]:
+    for case in cases:
+        for value in case.good:
+            yield (case.element, value, False)
+        for value in case.bad:
+            yield (case.element, value, True)
+
+
+@pytest.mark.parametrize("element,value,error", list(to_test_params(CASES)))
+def test_element_validation_is_performed_on_given_types(element, value, error):
+    with pytest.raises(ValidationError) if error else no_raise():
+        element(value)

--- a/tests/dsl/elements/test_reprs.py
+++ b/tests/dsl/elements/test_reprs.py
@@ -55,6 +55,9 @@ class ObjectWrapper(Object):
         ),
         (String(), "String()"),
         (String(pattern=".*"), "String(pattern='.*')"),
+        (Element(), "Element()"),
+        (Element(default="foo"), "Element(default='foo')"),
+        (Element(minimum=1), "Element(minimum=1)"),
         (ObjectWrapper, "ObjectWrapper"),
         (StringWrapper, "StringWrapper"),
         (

--- a/tests/dsl/parser/test_parse_composition.py
+++ b/tests/dsl/parser/test_parse_composition.py
@@ -3,7 +3,7 @@ from typing import Any, Dict
 import pytest
 
 from statham.dsl.elements import AnyOf, Array, Element, Integer, OneOf, String
-from statham.dsl.exceptions import FeatureNotImplementedError
+from statham.dsl.exceptions import FeatureNotImplementedError, ValidationError
 from statham.dsl.parser import parse_composition, parse_element
 
 
@@ -92,3 +92,23 @@ def test_parse_composition_fails_with_no_composition_keywords():
 def test_parse_single_list_typed_schema_returns_one_type():
     parsed = parse_element({"type": ["string"]})
     assert parsed == String()
+
+
+class TestPrimitiveCompositionWithOuterKeywords:
+    @staticmethod
+    @pytest.fixture(scope="class")
+    def element():
+        schema = {
+            "type": "integer",
+            "oneOf": [
+                {"minimum": 1, "maximum": 3},
+                {"minimum": 2, "maximum": 4},
+            ],
+        }
+        return parse_element(schema)
+
+    @staticmethod
+    @pytest.mark.xfail(reason="Not implemented", strict=True)
+    def test_element_validates_type(element):
+        with pytest.raises(ValidationError):
+            element(3.5)

--- a/tests/dsl/parser/test_parse_element.py
+++ b/tests/dsl/parser/test_parse_element.py
@@ -16,3 +16,25 @@ def test_parsing_schema_with_unknown_fields_ignores_them():
 def test_parsing_schema_with_bad_type_raises():
     with pytest.raises(SchemaParseError):
         parse_element({"type": {}})
+
+
+def test_parse_element_with_arguments():
+    schema = {
+        "default": "foo",
+        "minItems": 3,
+        "maxItems": 5,
+        "minimum": 3,
+        "maximum": 5,
+        "minLength": 3,
+        "maxLength": 5,
+    }
+    expected = Element(
+        default="foo",
+        minItems=3,
+        maxItems=5,
+        minimum=3,
+        maximum=5,
+        minLength=3,
+        maxLength=5,
+    )
+    assert parse_element(schema) == expected


### PR DESCRIPTION
* Added support for `default` and validation keywords in un-typed
  schemas.

# Check list

## Before asking for a review

- [x] Target branch is `master`
- [x] `make test` passes locally.
- [x] [`[Unreleased]`](../blob/master/CHANGELOG.md#unreleased) section in [CHANGELOG.md](../blob/master/CHANGELOG.md) is updated.
- [x] I reviewed the "Files changed" tab and self-annotated anything unexpected.

## Before review (reviewer)

- [ ] All of the above are checked and true. **Review ALL items.** If not, return the PR to the author.
- [ ] Continuous Integration is passing. If not, return the PR to the author.

## After merge (reviewer)

- [ ] Any issues that may now be closed are closed.