### PR TITLE
Feature/all of keyword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Types of changes are:
 
 ## [Unreleased]
 ### Added
-* Add support for `allOf` keyword. Ensures match against all
+* Added support for `allOf` keyword. Ensures match against all
   schemas, returns instance of the first.
 
 ## [0.3.0] - 2020-03-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Types of changes are:
 ## [0.3.0] - 2020-03-29
 ### Added
 * Added `source` keyword argument to `Property`. This allows mapping
-  of input properties to differeing model attribute names.
+  of input properties to differing model attribute names.
 * Added support for `additionalProperties` keyword argument.
 * Added support for `default` as a property name in object schemas.
 * Added support for `self` as a property name in object schemas.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Types of changes are:
 * **Fixed** for any bug fixes.
 
 ## [Unreleased]
+### Added
+* Add support for `allOf` keyword. Ensures match against all
+  schemas, returns instance of the first.
 
 ## [0.3.0] - 2020-03-29
 ### Added

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ def _check_my_format(value: str) -> bool:
 - [ ] Built-in string format validation #6
 - [ ] Generic keywords: `enum` #8, `const` #9
 - [ ] Array keywords: `uniqueItems` #10, `contains`
-- [ ] `not` keyword
+- [ ] `not` keyword #14
 - [ ] `minProperties`, `maxProperties` #15
 - [ ] Property dependencies
 - [ ] Schema dependencies

--- a/README.md
+++ b/README.md
@@ -84,13 +84,13 @@ def _check_my_format(value: str) -> bool:
 - [x] Type-specific validation (pattern, format, minimum, maximum etc)
 - [x] Custom string format validation
 - [x] Remote references
-- [x] `anyOf`, `oneOf`
+- [x] `anyOf`, `oneOf`, `allOf`
 - [x] `additionalProperties`
 - [ ] Tuple validation of arrays
 - [ ] Built-in string format validation #6
 - [ ] Generic keywords: `enum` #8, `const` #9
 - [ ] Array keywords: `uniqueItems` #10, `contains`
-- [ ] Composition keywords: `allOf` #12, `not` #14)
+- [ ] `not` keyword
 - [ ] `minProperties`, `maxProperties` #15
 - [ ] Property dependencies
 - [ ] Schema dependencies

--- a/statham/dsl/elements/__init__.py
+++ b/statham/dsl/elements/__init__.py
@@ -1,7 +1,12 @@
 from statham.dsl.elements.array import Array
 from statham.dsl.elements.base import Element
 from statham.dsl.elements.boolean import Boolean
-from statham.dsl.elements.composition import AnyOf, CompositionElement, OneOf
+from statham.dsl.elements.composition import (
+    AllOf,
+    AnyOf,
+    CompositionElement,
+    OneOf,
+)
 from statham.dsl.elements.meta import ObjectOptions
 from statham.dsl.elements.null import Null
 from statham.dsl.elements.numeric import Integer, Number

--- a/statham/dsl/elements/composition.py
+++ b/statham/dsl/elements/composition.py
@@ -54,7 +54,7 @@ class CompositionElement(Element):
 
 
 class AnyOf(CompositionElement):
-    """Must match at least on of the provided schemas."""
+    """Must match at least one of the provided schemas."""
 
     mode: Mode = "anyOf"
 

--- a/statham/dsl/elements/composition.py
+++ b/statham/dsl/elements/composition.py
@@ -25,7 +25,6 @@ class CompositionElement(Element):
 
     The "oneOf" and "anyOf" schemas share the same interface.
     # TODO: not
-    # TODO: allOf
     # TODO: Support outer keywords
     """
 

--- a/statham/dsl/elements/composition.py
+++ b/statham/dsl/elements/composition.py
@@ -1,5 +1,5 @@
-from abc import abstractmethod
 from typing import Any, List, NamedTuple, Optional
+from typing_extensions import Literal
 
 from statham.dsl.elements.base import Element
 from statham.dsl.exceptions import ValidationError
@@ -9,6 +9,9 @@ from statham.dsl.constants import NotPassed
 
 # TODO: if, then, else
 
+# This is a type annotation.
+Mode = Literal["anyOf", "oneOf", "allOf"]  # pylint: disable=invalid-name
+
 
 class CompositionElement(Element):
     """Composition Base Element.
@@ -17,6 +20,8 @@ class CompositionElement(Element):
     # TODO: not
     # TODO: allOf
     """
+
+    mode: Mode
 
     def __init__(self, *elements: Element, default: Any = NotPassed()):
         super().__init__()
@@ -34,40 +39,35 @@ class CompositionElement(Element):
         )
         return f"Union[{annotations}]"
 
-    @abstractmethod
-    def construct(self, _value: Any, property_: _Property):
-        raise NotImplementedError
+    def construct(self, value: Any, property_: _Property):
+        if not getattr(self, "mode", None):
+            raise NotImplementedError
+        return _attempt_schemas(self.elements, value, property_, mode=self.mode)
 
 
 class AnyOf(CompositionElement):
-    """Any one of a list of possible models/sub-schemas."""
+    """Must match at least on of the provided schemas."""
 
-    def construct(self, value: Any, property_: _Property):
-        """Return against the first matching schema."""
-        return _attempt_schemas(self.elements, value, property_)[0]
+    mode: Mode = "anyOf"
 
 
 class OneOf(CompositionElement):
-    """Exactly one of a list of possible models/sub-schemas."""
+    """Must match exactly one of the provided schemas.."""
 
-    def construct(self, value: Any, property_: _Property):
-        """Ensure there is only one matching schema.
+    mode: Mode = "oneOf"
 
-        :raises ValidationError: if there are multiple matching schemas.
-        """
-        instantiated = _attempt_schemas(self.elements, value, property_)
-        if len(instantiated) > 1:
-            raise ValidationError.mutliple_composition_match(
-                [type(instance) for instance in instantiated], value
-            )
-        return instantiated[0]
+
+class AllOf(CompositionElement):
+    """Must match all provided schemas."""
+
+    mode: Mode = "allOf"
 
 
 class Outcome(NamedTuple):
 
     target: Element
     result: Optional[Any] = None
-    error: Optional[str] = None
+    error: Optional[Exception] = None
 
 
 def _attempt_schema(
@@ -81,28 +81,47 @@ def _attempt_schema(
     try:
         return Outcome(element, result=element(value, property_), error=None)
     except (TypeError, ValidationError) as exc:
-        return Outcome(element, result=None, error=str(exc))
+        return Outcome(element, result=None, error=exc)
 
 
 def _attempt_schemas(
-    elements: List[Element], value: Any, property_: _Property
-) -> List[Any]:
+    elements: List[Element],
+    value: Any,
+    property_: _Property,
+    mode: str = "anyOf",
+) -> Any:
     """Attempt to instantiate a given input against many elements.
 
     :param elements: The elements against which to validate.
     :param property_: The enclosing property.
     :param value: The data to validate against.
+    :param mode: The matching stategy to use. "allOf", "anyOf" or "oneOf".
     :return: A list of successful instantiations against `elements`.
     :raises ValidationError: if there are no matching schemas.
+    :raises ValueError: if passed an invalid mode.
     """
     outcomes = [
         _attempt_schema(element, value, property_) for element in elements
     ]
     results = [outcome.result for outcome in outcomes if not outcome.error]
-    if results:
-        return results
-    raise ValidationError.composite(
-        property_,
-        value,
-        [outcome.error for outcome in outcomes if outcome.error],
-    )
+    errors = [outcome.error for outcome in outcomes if outcome.error]
+    if not results:
+        raise ValidationError.combine(
+            property_, value, errors, "Does not match any accepted schema."
+        )
+
+    if mode == "anyOf":
+        return results[0]
+    if mode == "oneOf":
+        if len(results) > 1:
+            raise ValidationError.multiple_composition_match(
+                [type(instance) for instance in results], value
+            )
+        return results[0]
+    if mode == "allOf":
+        if errors:
+            raise ValidationError.combine(
+                property_, value, errors, "Does not match all required schemas."
+            )
+        return results[0]
+    raise ValueError(f"Got bad argument for `mode`: {mode}")  # pragma: no cover

--- a/statham/dsl/elements/composition.py
+++ b/statham/dsl/elements/composition.py
@@ -19,6 +19,7 @@ class CompositionElement(Element):
     The "oneOf" and "anyOf" schemas share the same interface.
     # TODO: not
     # TODO: allOf
+    # TODO: Support outer keywords
     """
 
     mode: Mode

--- a/statham/dsl/exceptions.py
+++ b/statham/dsl/exceptions.py
@@ -32,18 +32,18 @@ class ValidationError(StathamError):
         )
 
     @classmethod
-    def composite(cls, property_, value, messages) -> "ValidationError":
+    def combine(
+        cls, property_, value, exceptions, message
+    ) -> "ValidationError":
         base_message = str(cls.from_validator(property_, value, ""))
-        message = ", ".join(messages)
-        message = message.replace(base_message, "")
+        error_breakdown = ", ".join(str(exc) for exc in exceptions)
+        error_breakdown = error_breakdown.replace(base_message, "")
         return cls.from_validator(
-            property_,
-            value,
-            f"Does not match any accepted schema. Individual errors: {message}",
+            property_, value, message + f" Individual errors: {error_breakdown}"
         )
 
     @classmethod
-    def mutliple_composition_match(cls, matching_models, data):
+    def multiple_composition_match(cls, matching_models, data):
         return cls(
             "Matches multiple possible models. Must only match one.\n"
             f"Data: {data}\n"

--- a/tests/dsl/elements/test_composition.py
+++ b/tests/dsl/elements/test_composition.py
@@ -3,15 +3,24 @@ from typing import Any, Type
 import pytest
 
 from statham.dsl.constants import NotPassed
-from statham.dsl.elements import AnyOf, Array, CompositionElement, OneOf, String
+from statham.dsl.elements import (
+    AllOf,
+    AnyOf,
+    Array,
+    CompositionElement,
+    Object,
+    OneOf,
+    String,
+)
 from statham.dsl.helpers import Args
+from statham.dsl.property import Property
 from tests.dsl.elements.helpers import assert_validation
 from tests.helpers import no_raise
 
 
 class TestCompositionInstantiation:
     @staticmethod
-    @pytest.mark.parametrize("element", [OneOf, AnyOf])
+    @pytest.mark.parametrize("element", [OneOf, AnyOf, AllOf])
     @pytest.mark.parametrize(
         "args", [Args(String()), Args(String(), Array(String()))]
     )
@@ -22,7 +31,7 @@ class TestCompositionInstantiation:
             _ = args.apply(element)
 
     @staticmethod
-    @pytest.mark.parametrize("element", [OneOf, AnyOf])
+    @pytest.mark.parametrize("element", [OneOf, AnyOf, AllOf])
     @pytest.mark.parametrize("args", [Args()])
     def test_element_raises_on_bad_args(
         element: Type[CompositionElement], args: Args
@@ -104,15 +113,79 @@ class TestAnyOfValidation(CompositionValidation):
         )
 
 
+class TestAllOfValidation:
+    @staticmethod
+    @pytest.mark.parametrize(
+        "success,value",
+        [
+            (True, NotPassed()),
+            (False, "fo"),
+            (False, "foobar"),
+            (True, "foob"),
+            (False, ["foo"]),
+            (False, None),
+        ],
+    )
+    def test_validation_behaves_as_expected_on_primitives(
+        success: bool, value: Any
+    ):
+        assert_validation(
+            AllOf(String(maxLength=5), String(minLength=3)), success, value
+        )
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        "success,value",
+        [
+            (True, NotPassed()),
+            (False, None),
+            (False, ["foo"]),
+            (False, "foo"),
+            (True, {}),
+            (True, {"value": "foo"}),
+            (True, {"other_value": "foo"}),
+            (True, {"value": "foo", "other_value": "bar"}),
+        ],
+    )
+    def test_validation_behaves_as_expected_on_objects(
+        success: bool, value: Any
+    ):
+        class Foo(Object):
+            value = Property(String())
+
+        class Bar(Object):
+            other_value = Property(String())
+
+        assert_validation(AllOf(Foo, Bar), success, value)
+
+    @staticmethod
+    def test_first_match_is_returned():
+        class Foo(Object):
+            value = Property(String())
+
+        class Bar(Object):
+            other_value = Property(String())
+
+        result = AllOf(Foo, Bar)({"value": "foo", "other_value": "bar"})
+        assert isinstance(result, Foo)
+        assert result.value == "foo"
+        assert result.additional_properties["other_value"] == "bar"
+
+
 def test_composition_default_keyword():
     element = OneOf(String(), Array(String()), default="foo")
     assert element(NotPassed()) == "foo"
     assert element(["foo"]) == ["foo"]
 
 
-@pytest.mark.parametrize("element", [OneOf, AnyOf])
+@pytest.mark.parametrize("element", [OneOf, AnyOf, AllOf])
 def test_composition_annotation(element):
     assert element(String()).annotation == "str"
     assert (
         element(String(), Array(String())).annotation == "Union[str, List[str]]"
     )
+
+
+def test_instantiating_base_element_raises_not_implemented_error():
+    with pytest.raises(NotImplementedError):
+        _ = CompositionElement(String())("foo")

--- a/tests/dsl/parser/test_parse_composition.py
+++ b/tests/dsl/parser/test_parse_composition.py
@@ -2,7 +2,15 @@ from typing import Any, Dict
 
 import pytest
 
-from statham.dsl.elements import AnyOf, Array, Element, Integer, OneOf, String
+from statham.dsl.elements import (
+    AllOf,
+    AnyOf,
+    Array,
+    Element,
+    Integer,
+    OneOf,
+    String,
+)
 from statham.dsl.exceptions import FeatureNotImplementedError, ValidationError
 from statham.dsl.parser import parse_composition, parse_element
 
@@ -61,6 +69,11 @@ def test_parse_composition_fails_with_empty_list(keyword):
             },
             OneOf(String(), Array(String())),
             id="oneOf-with-multiple-sub-elements",
+        ),
+        pytest.param(
+            {"allOf": [{"type": "string"}, {"minLength": 3}]},
+            AllOf(String(), Element(minLength=3)),
+            id="allOf-with-multiple-sub-elements",
         ),
     ],
 )

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -139,6 +139,29 @@ class Foo(Object):
     )
 
 
+def test_parse_and_serialize_schema_with_composition_keywords():
+    schema = {
+        "type": "object",
+        "title": "MyObject",
+        "properties": {
+            "any": {"anyOf": [{"type": "string"}, {"minLength": 3}]},
+            "all": {"allOf": [{"type": "string"}, {"minLength": 3}]},
+            "one": {"oneOf": [{"type": "string"}, {"minLength": 3}]},
+        },
+    }
+    # pylint: disable=line-too-long
+    assert serialize_python(*parse(schema)) == _IMPORT_STATEMENTS + (
+        """class MyObject(Object):
+
+    any: Maybe[Any] = Property(AnyOf(String(), Element(minLength=3)))
+
+    all: Maybe[str] = Property(AllOf(String(), Element(minLength=3)))
+
+    one: Maybe[Any] = Property(OneOf(String(), Element(minLength=3)))
+"""
+    )
+
+
 def test_annotation_for_property_with_default_is_not_maybe():
     prop = Property(String(default="sample"), required=False)
     assert prop.annotation == "str"


### PR DESCRIPTION
Any related Github Issues?: #12  

* Added support for `allOf` keyword. Ensures match against all
  schemas, returns instance of the first.

# Check list

## Before asking for a review

- [x] Target branch is `master`
- [x] `make test` passes locally.
- [x] [`[Unreleased]`](../blob/master/CHANGELOG.md#unreleased) section in [CHANGELOG.md](../blob/master/CHANGELOG.md) is updated.
- [x] I reviewed the "Files changed" tab and self-annotated anything unexpected.

## Before review (reviewer)

- [ ] All of the above are checked and true. **Review ALL items.** If not, return the PR to the author.
- [ ] Continuous Integration is passing. If not, return the PR to the author.

## After merge (reviewer)

- [ ] Any issues that may now be closed are closed.