### PR TITLE
Feature/multiple composition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Types of changes are:
 ### Added
 * Added support for `allOf` keyword. Ensures match against all
   schemas, returns instance of the first.
+* Added support for multiple composition keywords within one schema,
+  including compositions of outer keywords and composition keywords.
 
 ## [0.3.0] - 2020-03-29
 ### Added

--- a/statham/dsl/constants.py
+++ b/statham/dsl/constants.py
@@ -31,4 +31,4 @@ T = TypeVar("T")
 Maybe = Union[T, NotPassed]
 
 
-COMPOSITION_KEYWORDS = ("anyOf", "oneOf")
+COMPOSITION_KEYWORDS = ("anyOf", "oneOf", "allOf")

--- a/statham/dsl/elements/composition.py
+++ b/statham/dsl/elements/composition.py
@@ -72,14 +72,29 @@ class AllOf(CompositionElement):
 
     @property
     def annotation(self):
-        """Must be the firt explicit type, otherwise Any."""
+        """Get type annotation for element.
+
+        With an AllOf element, this should be the most restrictive
+        type. On the assumption that the composition is possible, this
+        is chosen by returning the first explicit type annotation, or the
+        first union type annotation if no explicit annotations are
+        present.
+        """
         return next(
             (
                 elem.annotation
                 for elem in self.elements
                 if elem.annotation != "Any"
+                and not elem.annotation.startswith("Union")
             ),
-            "Any",
+            next(
+                (
+                    elem.annotation
+                    for elem in self.elements
+                    if elem.annotation != "Any"
+                ),
+                "Any",
+            ),
         )
 
 

--- a/statham/dsl/exceptions.py
+++ b/statham/dsl/exceptions.py
@@ -80,12 +80,5 @@ class FeatureNotImplementedError(SchemaParseError):
     """Functionality not yet implemented."""
 
     @classmethod
-    def multiple_composition_keywords(cls) -> "FeatureNotImplementedError":
-        return cls(
-            "Schema has multiple composition keywords. "
-            "This is not yet supported."
-        )
-
-    @classmethod
     def tuple_array_items(cls) -> "FeatureNotImplementedError":
         return cls("Tuple array items are not supported.")

--- a/statham/dsl/helpers.py
+++ b/statham/dsl/helpers.py
@@ -1,6 +1,6 @@
 from functools import wraps
 import inspect
-from typing import Tuple, Type, Union
+from typing import Any, Callable, Container, Dict, Tuple, Type, TypeVar, Union
 
 
 class Args:
@@ -64,3 +64,21 @@ def reraise(catch: ExceptionTypes, throw: Type[Exception], message: str):
         return _wrapper
 
     return _decorator
+
+
+T = TypeVar("T")
+
+
+def split_dict(
+    keys: Container[T]
+) -> Callable[[Dict[T, Any]], Tuple[Dict[T, Any], Dict[T, Any]]]:
+    """Split a dictionary on matching and non-matching keys."""
+
+    def _split(dictionary: Dict[T, Any]) -> Tuple[Dict[T, Any], Dict[T, Any]]:
+        match = {key: value for key, value in dictionary.items() if key in keys}
+        complement = {
+            key: value for key, value in dictionary.items() if key not in keys
+        }
+        return match, complement
+
+    return _split

--- a/statham/dsl/parser.py
+++ b/statham/dsl/parser.py
@@ -108,55 +108,39 @@ def parse_composition(
 ) -> Element:
     """Parse a schema with composition keywords.
 
-    :raises ValueError: if the schema does not contain any composition
-        keywords.
-    :raises FeatureNotImplementedError: if multiple composition keywords
-        are present.
+    Handles multiple composition keywords by wrapping them in an AllOf
+    element. Similarly, non-keyword elements are parsed as usual and
+    included in an allOf element.
+
+    For example:
+    ```python
+    schema = {
+        "type": "integer",
+        "oneOf": [{"minimum": 3}, {"maximum": 5}],
+        "anyOf": [{"multipleOf": 2}, {"multipleOf": 3}],
+    }
+    parse_composition(schema) == AllOf(
+        Integer(),
+        OneOf(Element(minimum=3), Element(maximum=5)),
+        AnyOf(Element(multipleOf=2), Element(multipleOf=3)),
+    )
+    ```
     """
     state = state or ParseState()
-    composition, other = split_dict(COMPOSITION_KEYWORDS)(schema)
+    composition, other = split_dict(set(COMPOSITION_KEYWORDS) | {"default"})(
+        schema
+    )
     base_element = parse_element(other, state)
     for key in COMPOSITION_KEYWORDS:
         composition[key] = [
             parse_element(sub_schema) for sub_schema in composition.get(key, [])
         ]
-    if base_element != Element():
-        composition["allOf"] = [base_element] + composition["allOf"]
-    for key, element in [("oneOf", OneOf), ("anyOf", AnyOf)]:
-        if not composition[key]:
-            continue
-        if len(composition[key]) == 1:
-            composition["allOf"].append(composition[key][0])
-        else:
-            composition["allOf"].append(element(*composition[key]))
-    any_of = composition["anyOf"]
-    if not any_of:
-        return Element()
-    if len(any_of) == 1:
-        return any_of[0]
-    return AnyOf(*any_of)
-
-    # intersect = {"anyOf", "oneOf", "allOf"} & set(schema)
-    # element_type: Type[CompositionElement]
-    # if intersect == {"anyOf"}:
-    #     element_type = AnyOf
-    #     sub_schemas = schema["anyOf"]
-    # elif intersect == {"oneOf"}:
-    #     element_type = OneOf
-    #     sub_schemas = schema["oneOf"]
-    # elif intersect == {"allOf"}:
-    #     element_type = AllOf
-    #     sub_schemas = schema["allOf"]
-    # elif not intersect:
-    #     raise ValueError(
-    #         "Schema passed to `parse_composition` has no supported "
-    #         "validation keywords."
-    #     )
-    # else:
-    #     raise FeatureNotImplementedError.multiple_composition_keywords()
-    # return element_type(
-    #     *(parse_element(sub_schema, state) for sub_schema in sub_schemas)
-    # )
+    all_of = [base_element] + composition["allOf"]
+    all_of.append(_compose_elements(OneOf, composition["oneOf"]))
+    all_of.append(_compose_elements(AnyOf, composition["anyOf"]))
+    element = _compose_elements(AllOf, all_of)
+    element.default = composition.get("default") or element.default
+    return element
 
 
 def parse_typed(
@@ -300,6 +284,22 @@ def parse_items(schema: Dict[str, Any], state: ParseState = None) -> Element:
     if isinstance(items, list):
         raise FeatureNotImplementedError.tuple_array_items()
     return parse_element(items, state)
+
+
+def _compose_elements(
+    element_type: Type[CompositionElement], elements: List[Element]
+) -> Element:
+    """Create a composition element from a type and list of component elements.
+
+    Filters out trivial elements, and simplifies compositions with only one
+    composed element.
+    """
+    elements = [elem for elem in elements if elem != Element()]
+    if not elements:
+        return Element()
+    if len(elements) == 1:
+        return elements[0]
+    return element_type(*elements)
 
 
 def keyword_filter(type_: Type) -> Callable[[Dict[str, Any]], Dict[str, Any]]:

--- a/tests/dsl/elements/test_composition.py
+++ b/tests/dsl/elements/test_composition.py
@@ -225,3 +225,10 @@ def test_all_of_annotation(element, annotation):
 def test_instantiating_base_element_raises_not_implemented_error():
     with pytest.raises(NotImplementedError):
         _ = CompositionElement(String())("foo")
+
+
+def test_default_does_not_affect_sub_schema_attempts():
+    element = OneOf(String(), String(default="foo"))
+    with no_raise():
+        result = element(NotPassed())
+    assert result is NotPassed()

--- a/tests/dsl/elements/test_composition.py
+++ b/tests/dsl/elements/test_composition.py
@@ -215,6 +215,7 @@ def test_composition_untyped_annotation_overrides(element):
         (AllOf(String(minLength=3), Element(maxLength=5)), "str"),
         (AllOf(String(minLength=3), Array(String())), "str"),
         (AllOf(Array(String()), String(minLength=3)), "List[str]"),
+        (AllOf(OneOf(String(), Array(String())), String()), "str"),
     ],
 )
 def test_all_of_annotation(element, annotation):


### PR DESCRIPTION
* Added support for multiple composition keywords within one schema,
  including compositions of outer keywords and composition keywords.

# Check list

## Before asking for a review

- [x] Target branch is `master`
- [x] `make test` passes locally.
- [x] [`[Unreleased]`](../blob/master/CHANGELOG.md#unreleased) section in [CHANGELOG.md](../blob/master/CHANGELOG.md) is updated.
- [x] I reviewed the "Files changed" tab and self-annotated anything unexpected.

## Before review (reviewer)

- [ ] All of the above are checked and true. **Review ALL items.** If not, return the PR to the author.
- [ ] Continuous Integration is passing. If not, return the PR to the author.

## After merge (reviewer)

- [ ] Any issues that may now be closed are closed.