### PR TITLE
Feature/handle bad python names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ Types of changes are:
 * Added support for multiple composition keywords within one schema,
   including compositions of outer keywords and composition keywords.
 
+### Changed
+* Property names which are not valid python attribute names are now
+  mapped to a valid python attribute. Whitespace is replaced by "_"
+  and symbols are assigned their Unicode names.
+
 ## [0.3.0] - 2020-03-29
 ### Added
 * Added `source` keyword argument to `Property`. This allows mapping

--- a/statham/dsl/elements/composition.py
+++ b/statham/dsl/elements/composition.py
@@ -23,7 +23,7 @@ def _dedupe(seq: Iterable[T]) -> List[T]:
 class CompositionElement(Element):
     """Composition Base Element.
 
-    The "oneOf" and "anyOf" schemas share the same interface.
+    The "oneOf", "anyOf" and "allOf" elements share the same interface.
     # TODO: not
     """
 

--- a/statham/dsl/helpers.py
+++ b/statham/dsl/helpers.py
@@ -82,3 +82,8 @@ def split_dict(
         return match, complement
 
     return _split
+
+
+def expand(function):
+    """Useful for functional operations like map."""
+    return lambda args: function(*args)

--- a/statham/dsl/property.py
+++ b/statham/dsl/property.py
@@ -38,7 +38,11 @@ class _Property(Generic[PropType]):
     def __eq__(self, other):
         if not isinstance(other, _Property):
             return False
-        return self.element == other.element and self.required == other.required
+        return (
+            self.element == other.element
+            and self.required == other.required
+            and self.source == other.source
+        )
 
     def evolve(self, name: str) -> "_Property":
         """Generate renamed property object to pass into nested elements."""

--- a/tests/dsl/parser/test_parse_attribute_name.py
+++ b/tests/dsl/parser/test_parse_attribute_name.py
@@ -1,0 +1,28 @@
+import pytest
+
+from statham.dsl.parser import parse_attribute_name
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        ("name", "name"),
+        ("default", "_default"),
+        ("properties", "_properties"),
+        ("options", "_options"),
+        ("additional_properties", "_additional_properties"),
+        ("__init__", "___init__"),
+        ("name with space", "name_with_space"),
+        ("lowerCamelCase", "lowerCamelCase"),
+        ("name_with_number_6", "name_with_number_6"),
+        ("6_leading_number", "_6_leading_number"),
+        ("name_with_$", "name_with_dollar_sign"),
+        ("", "blank"),
+        ("+", "plus_sign"),
+        ("$ref", "dollar_sign_ref"),
+        ("ref$", "ref_dollar_sign"),
+        ("ref$ref", "ref_dollar_sign_ref"),
+    ],
+)
+def test_parse_attribute_name(name: str, expected: str):
+    assert parse_attribute_name(name) == expected

--- a/tests/dsl/parser/test_parse_object.py
+++ b/tests/dsl/parser/test_parse_object.py
@@ -210,9 +210,9 @@ def test_parse_object_with_invalid_names():
     }
 
     class BadNames(Object):
-        dollar_sign_ref = Property(Element())
-        a_sentence = Property(Element())
-        multiple_lines = Property(Element())
-        _10 = Property(Element())
+        dollar_sign_ref = Property(Element(), source="$ref")
+        a_sentence = Property(Element(), source="a sentence")
+        multiple_lines = Property(Element(), source="multiple\nlines")
+        _10 = Property(Element(), source="10")
 
     assert parse_element(schema) == BadNames

--- a/tests/dsl/parser/test_parse_object.py
+++ b/tests/dsl/parser/test_parse_object.py
@@ -186,3 +186,33 @@ class TestParseState:
         assert len(state.seen["Foo"]) == 2
         assert state.seen["Foo"][0] is base_type
         assert state.seen["Foo"][1] is distinct
+
+
+def test_parse_object_with_required_not_properties():
+    schema = {"type": "object", "title": "NoProperties", "required": ["value"]}
+
+    class NoProperties(Object):
+        value = Property(Element(), required=True)
+
+    assert parse_element(schema) == NoProperties
+
+
+def test_parse_object_with_invalid_names():
+    schema = {
+        "type": "object",
+        "title": "BadNames",
+        "properties": {
+            "$ref": {},
+            "a sentence": {},
+            "multiple\nlines": {},
+            "10": {},
+        },
+    }
+
+    class BadNames(Object):
+        dollar_sign_ref = Property(Element())
+        a_sentence = Property(Element())
+        multiple_lines = Property(Element())
+        _10 = Property(Element())
+
+    assert parse_element(schema) == BadNames

--- a/tests/dsl/test_comparators.py
+++ b/tests/dsl/test_comparators.py
@@ -20,6 +20,10 @@ class Mux(Object):
     value = Property(Array(String()))
 
 
+class Qux(Object):
+    value = Property(String(), source="_value")
+
+
 @pytest.mark.parametrize(
     "left,right",
     [
@@ -43,6 +47,7 @@ def test_equivalent_schemas_are_equal(left, right):
         (Array(String()), Array(String(minLength=3))),
         (Foo, Baz),
         (Foo, Mux),
+        (Foo, Qux),
     ],
 )
 def test_non_equivalent_schemas_are_not_equal(left, right):


### PR DESCRIPTION

### Changed
* Property names which are not valid python attribute names are now
  mapped to a valid python attribute. Whitespace is replaced by "_"
  and symbols are assigned their Unicode names.

# Check list

## Before asking for a review

- [x] Target branch is `master`
- [x] `make test` passes locally.
- [x] [`[Unreleased]`](../blob/master/CHANGELOG.md#unreleased) section in [CHANGELOG.md](../blob/master/CHANGELOG.md) is updated.
- [x] I reviewed the "Files changed" tab and self-annotated anything unexpected.

## Before review (reviewer)

- [ ] All of the above are checked and true. **Review ALL items.** If not, return the PR to the author.
- [ ] Continuous Integration is passing. If not, return the PR to the author.

## After merge (reviewer)

- [ ] Any issues that may now be closed are closed.