### PR TITLE
Feature/add official jsonschema test suite

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tests/JSON-Schema-Test-Suite"]
+	path = tests/JSON-Schema-Test-Suite
+	url = https://github.com/json-schema-org/JSON-Schema-Test-Suite

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,21 @@ Types of changes are:
 * **Fixed** for any bug fixes.
 
 ## [Unreleased]
+### Added
+* Git submodule containing official JSON Schema test suite, and a
+  corresponding parameterized test. These tests will run if environment
+  variable `OFFICIAL_TEST_SUITE` is set to `true`.
+
 ### Fixed
 * Fixed bug causing some properties to be parsed twice.
 * Properties which conflict with Python keywords are now re-mapped
   on generated models.
 * Fixed bug where default is overriden on Object classes in parsers.
 * Fixed bug causing partially duplicated properties.
+* `Number` schema elements now accept `int` values, but convert them
+  to `float`.
+* Fixed bug causing some subschemas in `oneOf` statements to be
+  skipped.
 
 ## [0.4.0] - 2020-03-29
 ### Added

--- a/statham/dsl/elements/composition.py
+++ b/statham/dsl/elements/composition.py
@@ -149,7 +149,8 @@ def _attempt_schemas(
     if mode == "oneOf":
         if len(results) > 1:
             raise ValidationError.multiple_composition_match(
-                [type(instance) for instance in results], value
+                [outcome.target for outcome in outcomes if not outcome.error],
+                value,
             )
         return results[0]
     if mode == "allOf":

--- a/statham/dsl/elements/numeric.py
+++ b/statham/dsl/elements/numeric.py
@@ -55,6 +55,9 @@ class Number(NumericElement[float]):
     Provides supported validation settings via keyword arguments.
     """
 
+    def construct(self, value, _property):  # pylint: disable=no-self-use
+        return float(value)
+
     @property
     def type_validator(self):
-        return InstanceOf(float)
+        return InstanceOf(float, int)

--- a/statham/dsl/parser.py
+++ b/statham/dsl/parser.py
@@ -139,7 +139,9 @@ def parse_composition(
             parse_element(sub_schema) for sub_schema in composition.get(key, [])
         ]
     all_of = [base_element] + composition["allOf"]
-    all_of.append(_compose_elements(OneOf, composition["oneOf"]))
+    all_of.append(
+        _compose_elements(OneOf, composition["oneOf"], simplify=False)
+    )
     all_of.append(_compose_elements(AnyOf, composition["anyOf"]))
     element = _compose_elements(AllOf, all_of)
     default = schema.get("default", NotPassed())
@@ -331,14 +333,16 @@ def parse_items(schema: Dict[str, Any], state: ParseState = None) -> Element:
 
 
 def _compose_elements(
-    element_type: Type[CompositionElement], elements: List[Element]
+    element_type: Type[CompositionElement],
+    elements: List[Element],
+    simplify: bool = True,
 ) -> Element:
     """Create a composition element from a type and list of component elements.
 
     Filters out trivial elements, and simplifies compositions with only one
     composed element.
     """
-    elements = [elem for elem in elements if elem != Element()]
+    elements = [elem for elem in elements if not simplify or elem != Element()]
     if not elements:
         return Element()
     if len(elements) == 1:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,0 @@
-# TODO: Integrate with JSON Schema official test suite.

--- a/tests/component/test_field_validation.py
+++ b/tests/component/test_field_validation.py
@@ -97,7 +97,7 @@ FIELD_VALIDATION_PARAMS: List[
     (
         {"number_no_validation": None},
         ValidationError,
-        "Must be of type (float).",
+        "Must be of type (float,int).",
     ),
     (
         {"number_minimum": 2.4},

--- a/tests/component/test_union_types.py
+++ b/tests/component/test_union_types.py
@@ -12,7 +12,7 @@ FIELD_VALIDATION_PARAMS: List[
 ] = [
     ({}, None, None),
     ({"number_integer": None}, ValidationError, "Must be of type (int)."),
-    ({"number_integer": None}, ValidationError, "Must be of type (float)."),
+    ({"number_integer": None}, ValidationError, "Must be of type (float,int)."),
     (
         {"number_integer": 1},
         ValidationError,

--- a/tests/dsl/elements/test_numeric.py
+++ b/tests/dsl/elements/test_numeric.py
@@ -170,7 +170,7 @@ class TestNumberValidation:
             (True, NotPassed()),
             (True, 3.6),
             (True, 12.7),
-            (False, 1),
+            (True, 1),
             (False, ["foo"]),
             (False, None),
         ],

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -1,4 +1,3 @@
-# TODO: Integrate with JSON Schema official test suite.
 import json
 import os
 from os import path

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -62,7 +62,7 @@ def load_file(filepath: str) -> Optional[List]:
 
 
 DIRECTORY = "tests/JSON-Schema-Test-Suite/tests"
-SUPPORTED_DRAFTS = ("draft4",)
+SUPPORTED_DRAFTS = ("draft6",)
 
 
 class Param(NamedTuple):
@@ -128,8 +128,9 @@ def _extract_tests(directory: str) -> Iterator[Param]:
 
 @pytest.mark.parametrize("param", _extract_tests(DIRECTORY), ids=str)
 def test_jsonschema_official_test(param: Param):
+    schema = {**param.schema, "title": "Test"}
     try:
-        element = parse_element(param.schema)
+        element = parse_element(schema)
     except FeatureNotImplementedError:
         return
     with no_raise() if param.valid else pytest.raises(


### PR DESCRIPTION
### Added
* Git submodule containing official JSON Schema test suite, and a
  corresponding parameterized test. These tests will run if environment
  variable `OFFICIAL_TEST_SUITE` is set to `true`.

### Fixed
* `Number` schema elements now accept `int` values, but convert them
  to `float`.
* Fixed bug causing some subschemas in `oneOf` statements to be
  skipped.

# Check list

## Before asking for a review

- [x] Target branch is `master`
- [x] `make test` passes locally.
- [x] [`[Unreleased]`](../blob/master/CHANGELOG.md#unreleased) section in [CHANGELOG.md](../blob/master/CHANGELOG.md) is updated.
- [x] I reviewed the "Files changed" tab and self-annotated anything unexpected.

## Before review (reviewer)

- [ ] All of the above are checked and true. **Review ALL items.** If not, return the PR to the author.
- [ ] Continuous Integration is passing. If not, return the PR to the author.

## After merge (reviewer)

- [ ] Any issues that may now be closed are closed.