### PR TITLE
Feature/allow boolean true schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Types of changes are:
   to `float`.
 * Fixed bug causing some subschemas in `oneOf` and `anyOf` statements
   to be skipped.
+* Fixed bug in `MultipleOf` due to floating point errors.
 
 ## [0.4.0] - 2020-03-29
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Types of changes are:
 * Git submodule containing official JSON Schema test suite, and a
   corresponding parameterized test. These tests will run if environment
   variable `OFFICIAL_TEST_SUITE` is set to `true`.
+* Added support for boolean `true` schemas.
 
 ### Fixed
 * Fixed bug causing some properties to be parsed twice.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ Types of changes are:
   variable `OFFICIAL_TEST_SUITE` is set to `true`.
 * Added support for boolean `true` schemas.
 
+### Changed
+* Parsing schemas wih unsupported keywords now raises a
+  `FeatureNotImplementedError`.
+
 ### Fixed
 * Fixed bug causing some properties to be parsed twice.
 * Properties which conflict with Python keywords are now re-mapped
@@ -27,8 +31,8 @@ Types of changes are:
 * Fixed bug causing partially duplicated properties.
 * `Number` schema elements now accept `int` values, but convert them
   to `float`.
-* Fixed bug causing some subschemas in `oneOf` statements to be
-  skipped.
+* Fixed bug causing some subschemas in `oneOf` and `anyOf` statements
+  to be skipped.
 
 ## [0.4.0] - 2020-03-29
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Types of changes are:
 * Git submodule containing official JSON Schema test suite, and a
   corresponding parameterized test. These tests will run if environment
   variable `OFFICIAL_TEST_SUITE` is set to `true`.
-* Added support for boolean `true` schemas.
+* Added support for boolean schemas.
 
 ### Changed
 * Parsing schemas wih unsupported keywords now raises a

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ class Poll(Object):
     choices: List[Choice] = Property(Array(Choice), required=True)
 ```
 
+Development currently targets compatibility with JSONSchema Draft 6.
+
 # Requirements
 This package is currently tested for Python 3.6.
 

--- a/statham/dsl/constants.py
+++ b/statham/dsl/constants.py
@@ -32,3 +32,23 @@ Maybe = Union[T, NotPassed]
 
 
 COMPOSITION_KEYWORDS = ("anyOf", "oneOf", "allOf")
+
+
+UNSUPPORTED_SCHEMA_KEYWORDS = {
+    "additionalItems",
+    "const",
+    "contains",
+    "$defs",
+    "enum",
+    "if",
+    "then",
+    "else",
+    "maxProperties",
+    "minProperties",
+    "not",
+    "patternProperties",
+    "propertyNames",
+    "unevaluatedItems",
+    "unevaluatedProperties",
+    "uniqueItems",
+}

--- a/statham/dsl/elements/__init__.py
+++ b/statham/dsl/elements/__init__.py
@@ -1,5 +1,5 @@
 from statham.dsl.elements.array import Array
-from statham.dsl.elements.base import Element
+from statham.dsl.elements.base import Element, Nothing
 from statham.dsl.elements.boolean import Boolean
 from statham.dsl.elements.composition import (
     AllOf,

--- a/statham/dsl/elements/base.py
+++ b/statham/dsl/elements/base.py
@@ -15,7 +15,12 @@ from typing import (
 
 from statham.dsl.constants import NotPassed, Maybe
 from statham.dsl.helpers import custom_repr
-from statham.dsl.validation import get_validators, InstanceOf, Validator
+from statham.dsl.validation import (
+    get_validators,
+    InstanceOf,
+    NoMatch,
+    Validator,
+)
 
 
 T = TypeVar("T")
@@ -148,6 +153,24 @@ class Element(Generic[T]):
         if isinstance(value, NotPassed):
             return value
         return self.construct(value, property_)
+
+
+class Nothing(Element):
+    """Element which matches nothing. Equivalent to False."""
+
+    def __init__(self):
+        super().__init__()  # Don't allow args to Nothing.
+
+    def __bool__(self):
+        return False
+
+    @property
+    def annotation(self) -> str:
+        return "None"
+
+    @property
+    def validators(self) -> List[Validator]:
+        return [NoMatch()]
 
 
 # Needs to be imported last to prevent cyclic import.

--- a/statham/dsl/exceptions.py
+++ b/statham/dsl/exceptions.py
@@ -84,10 +84,6 @@ class FeatureNotImplementedError(SchemaParseError):
         return cls("Tuple array items are not supported.")
 
     @classmethod
-    def false_schema(cls) -> "FeatureNotImplementedError":
-        return cls("Boolean false schemas are not supported.")
-
-    @classmethod
     def unsupported_keywords(cls, keywords) -> "FeatureNotImplementedError":
         return cls(
             f"The following provided keywords are not supported: {keywords}"

--- a/statham/dsl/exceptions.py
+++ b/statham/dsl/exceptions.py
@@ -82,3 +82,7 @@ class FeatureNotImplementedError(SchemaParseError):
     @classmethod
     def tuple_array_items(cls) -> "FeatureNotImplementedError":
         return cls("Tuple array items are not supported.")
+
+    @classmethod
+    def false_schema(cls) -> "FeatureNotImplementedError":
+        return cls("Boolean false schemas are not supported.")

--- a/statham/dsl/exceptions.py
+++ b/statham/dsl/exceptions.py
@@ -86,3 +86,9 @@ class FeatureNotImplementedError(SchemaParseError):
     @classmethod
     def false_schema(cls) -> "FeatureNotImplementedError":
         return cls("Boolean false schemas are not supported.")
+
+    @classmethod
+    def unsupported_keywords(cls, keywords) -> "FeatureNotImplementedError":
+        return cls(
+            f"The following provided keywords are not supported: {keywords}"
+        )

--- a/statham/dsl/parser.py
+++ b/statham/dsl/parser.py
@@ -18,6 +18,7 @@ from statham.dsl.elements import (
     Boolean,
     CompositionElement,
     Integer,
+    Nothing,
     Null,
     Number,
     Object,
@@ -83,7 +84,7 @@ def parse(schema: Dict[str, Any]) -> List[Element]:
     return [parse_element(schema, state)] + [
         parse_element(definition, state)
         for definition in schema.get("definitions", {}).values()
-        if isinstance(definition, (dict, Element))
+        if isinstance(definition, (dict, bool, Element))
     ]
 
 
@@ -97,9 +98,7 @@ def parse_element(
 ) -> Element:
     """Parse a JSONSchema element to a DSL Element object."""
     if isinstance(schema, bool):
-        if not schema:
-            raise FeatureNotImplementedError.false_schema()
-        return Element()
+        return Element() if schema else Nothing()
     state = state or ParseState()
     if isinstance(schema, Element):
         return schema
@@ -274,7 +273,7 @@ def parse_properties(
             )
             for key, value in properties.items()
             # Ignore malformed values.
-            if isinstance(value, dict)
+            if isinstance(value, (dict, bool))
         },
         **{
             parse_attribute_name(key): prop

--- a/statham/dsl/parser.py
+++ b/statham/dsl/parser.py
@@ -6,7 +6,11 @@ import string
 from typing import Any, Callable, DefaultDict, Dict, List, Type, Union
 import unicodedata
 
-from statham.dsl.constants import COMPOSITION_KEYWORDS, NotPassed
+from statham.dsl.constants import (
+    COMPOSITION_KEYWORDS,
+    NotPassed,
+    UNSUPPORTED_SCHEMA_KEYWORDS,
+)
 from statham.dsl.elements import (
     AllOf,
     AnyOf,
@@ -99,6 +103,10 @@ def parse_element(
     state = state or ParseState()
     if isinstance(schema, Element):
         return schema
+    if set(schema) & UNSUPPORTED_SCHEMA_KEYWORDS:
+        raise FeatureNotImplementedError.unsupported_keywords(
+            set(schema) & UNSUPPORTED_SCHEMA_KEYWORDS
+        )
     if "properties" in schema:
         schema["properties"] = parse_properties(schema, state)
     if "items" in schema:

--- a/statham/dsl/parser.py
+++ b/statham/dsl/parser.py
@@ -88,9 +88,14 @@ def parse(schema: Dict[str, Any]) -> List[Element]:
     SchemaParseError,
     "Could not parse cyclical dependencies of this schema.",
 )
-def parse_element(schema: Dict[str, Any], state: ParseState = None) -> Element:
+def parse_element(
+    schema: Union[bool, Dict[str, Any]], state: ParseState = None
+) -> Element:
     """Parse a JSONSchema element to a DSL Element object."""
-    # TODO: Allow true and false.
+    if isinstance(schema, bool):
+        if not schema:
+            raise FeatureNotImplementedError.false_schema()
+        return Element()
     state = state or ParseState()
     if isinstance(schema, Element):
         return schema

--- a/statham/dsl/parser.py
+++ b/statham/dsl/parser.py
@@ -155,7 +155,9 @@ def parse_composition(
     all_of.append(
         _compose_elements(OneOf, composition["oneOf"], simplify=False)
     )
-    all_of.append(_compose_elements(AnyOf, composition["anyOf"]))
+    all_of.append(
+        _compose_elements(AnyOf, composition["anyOf"], simplify=False)
+    )
     element = _compose_elements(AllOf, all_of)
     default = schema.get("default", NotPassed())
     if isinstance(element, ObjectMeta):

--- a/statham/dsl/validation/__init__.py
+++ b/statham/dsl/validation/__init__.py
@@ -1,7 +1,7 @@
 from typing import Iterator, Type
 
 from statham.dsl.validation.array import MinItems, MaxItems
-from statham.dsl.validation.base import InstanceOf, Validator
+from statham.dsl.validation.base import InstanceOf, NoMatch, Validator
 from statham.dsl.validation.numeric import (
     Minimum,
     Maximum,
@@ -28,7 +28,7 @@ def get_validators(element) -> Iterator[Validator]:
     parameters are present on the element with correct values.
     """
     for validator_type in _all_subclasses(Validator):
-        if validator_type is InstanceOf:
+        if validator_type in (InstanceOf, NoMatch):
             continue
         validator = validator_type.from_element(element)
         if validator:

--- a/statham/dsl/validation/base.py
+++ b/statham/dsl/validation/base.py
@@ -94,3 +94,12 @@ class InstanceOf(Validator):
             return
         if not _is_instance(value, self.params["types"]):
             raise ValidationError
+
+
+class NoMatch(Validator):
+    message = "Schema does not accept any values."
+
+    def validate(self, value: Any):
+        if value is NotPassed():
+            return
+        raise ValidationError

--- a/statham/dsl/validation/numeric.py
+++ b/statham/dsl/validation/numeric.py
@@ -49,5 +49,11 @@ class MultipleOf(Validator):
     message = "Must be a multiple of {multipleOf}."
 
     def validate(self, value: Any):
-        if value % self.params["multipleOf"]:
+        multiple_of = self.params["multipleOf"]
+        if isinstance(multiple_of, float):
+            quotient = value / multiple_of
+            if int(quotient) != quotient:
+                raise ValidationError
+            return
+        if value % multiple_of:
             raise ValidationError

--- a/tests/dsl/elements/test_element.py
+++ b/tests/dsl/elements/test_element.py
@@ -2,7 +2,7 @@ from typing import Any, Iterator, List, NamedTuple, Tuple
 import pytest
 
 from statham.dsl.constants import NotPassed
-from statham.dsl.elements import Element, String
+from statham.dsl.elements import Element, Nothing, String
 from statham.dsl.elements.base import _AnonymousObject
 from statham.dsl.exceptions import ValidationError
 from statham.dsl.property import _Property
@@ -152,6 +152,11 @@ CASES = [
             ["foo", 1],
         ],
         bad=[{}, {"foo": "bar"}],
+    ),
+    Case(
+        element=Nothing(),
+        good=[NotPassed()],
+        bad=[None, True, 1, 1.2, "foo", {"foo": "bar"}, ["foo", 1]],
     ),
 ]
 

--- a/tests/dsl/parser/test_parse_composition.py
+++ b/tests/dsl/parser/test_parse_composition.py
@@ -239,7 +239,7 @@ class TestPrimitiveCompositionWithOuterKeywords:
             _ = element(value)
 
 
-def test_parse_of_with_outer_default_does_not_override_other_element():
+def test_parse_allOf_with_outer_default_does_not_override_other_element():
     sub_schema = {"type": "object", "title": "Child"}
     schema = {"type": "object", "title": "Parent", "properties": {}}
     schema["properties"]["value"] = sub_schema
@@ -256,3 +256,10 @@ def test_parse_of_with_outer_default_does_not_override_other_element():
         other = Property(AllOf(Child, default={"foo": "bar"}))
 
     assert parse_element(schema) == Parent
+
+
+def test_parse_anyOf_with_one_empty_element():
+    schema = {"anyOf": [{"type": "number"}, {}]}
+    element = parse_element(schema)
+    with no_raise():
+        _ = element("foo")

--- a/tests/dsl/parser/test_parse_element.py
+++ b/tests/dsl/parser/test_parse_element.py
@@ -2,16 +2,25 @@ import pytest
 
 from statham.dsl.elements import Element, String
 from statham.dsl.property import Property
-from statham.dsl.exceptions import SchemaParseError
+from statham.dsl.exceptions import FeatureNotImplementedError, SchemaParseError
 from statham.dsl.parser import parse_element
 
 
 def test_parsing_empty_schema_results_in_base_element():
-    assert type(parse_element({})) is Element
+    assert parse_element({}) == Element()
 
 
 def test_parsing_schema_with_unknown_fields_ignores_them():
-    assert type(parse_element({"foo": "bar"})) is Element
+    assert parse_element({"foo": "bar"}) == Element()
+
+
+def test_parsing_boolean_schema_true_gives_base_element():
+    assert parse_element(True) == Element()
+
+
+@pytest.mark.xfail(raises=FeatureNotImplementedError)
+def test_parsing_boolean_schema_false():
+    assert parse_element(False)
 
 
 def test_parsing_schema_with_bad_type_raises():

--- a/tests/dsl/parser/test_parse_element.py
+++ b/tests/dsl/parser/test_parse_element.py
@@ -1,7 +1,7 @@
 import pytest
 
 from statham.dsl.constants import UNSUPPORTED_SCHEMA_KEYWORDS
-from statham.dsl.elements import Element, String
+from statham.dsl.elements import Element, Nothing, String
 from statham.dsl.property import Property
 from statham.dsl.exceptions import FeatureNotImplementedError, SchemaParseError
 from statham.dsl.parser import parse_element
@@ -19,9 +19,8 @@ def test_parsing_boolean_schema_true_gives_base_element():
     assert parse_element(True) == Element()
 
 
-@pytest.mark.xfail(raises=FeatureNotImplementedError)
-def test_parsing_boolean_schema_false():
-    assert parse_element(False)
+def test_parsing_boolean_schema_false_gives_nothing():
+    assert parse_element(False) == Nothing()
 
 
 @pytest.mark.xfail(raises=FeatureNotImplementedError)

--- a/tests/dsl/parser/test_parse_element.py
+++ b/tests/dsl/parser/test_parse_element.py
@@ -1,5 +1,6 @@
 import pytest
 
+from statham.dsl.constants import UNSUPPORTED_SCHEMA_KEYWORDS
 from statham.dsl.elements import Element, String
 from statham.dsl.property import Property
 from statham.dsl.exceptions import FeatureNotImplementedError, SchemaParseError
@@ -21,6 +22,12 @@ def test_parsing_boolean_schema_true_gives_base_element():
 @pytest.mark.xfail(raises=FeatureNotImplementedError)
 def test_parsing_boolean_schema_false():
     assert parse_element(False)
+
+
+@pytest.mark.xfail(raises=FeatureNotImplementedError)
+@pytest.mark.parametrize("keyword", UNSUPPORTED_SCHEMA_KEYWORDS)
+def test_parsing_unsupported_keywords(keyword):
+    assert parse_element({keyword: True})
 
 
 def test_parsing_schema_with_bad_type_raises():

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -25,6 +25,7 @@ NOT_IMPLEMENTED = (
     "anchor",
     "const",
     "contains",
+    "definitions",
     "defs",
     "dependentRequired",
     "dependentSchemas",
@@ -127,7 +128,9 @@ def _extract_tests(directory: str) -> Iterator[Param]:
 
 @pytest.mark.parametrize("param", _extract_tests(DIRECTORY), ids=str)
 def test_jsonschema_official_test(param: Param):
-    schema = {**param.schema, "title": "Test"}
+    schema = param.schema
+    if isinstance(schema, dict):
+        schema = {**param.schema, "title": "Test"}
     try:
         element = parse_element(schema)
     except FeatureNotImplementedError:

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -2,7 +2,7 @@ import pytest
 
 from statham.dsl.constants import NotPassed
 from statham.dsl.property import UNBOUND_PROPERTY
-from statham.dsl.validation import Format, Validator
+from statham.dsl.validation import Format, MultipleOf, Validator
 from tests.helpers import no_raise
 
 
@@ -36,3 +36,9 @@ def test_that_validator_fails_if_bad_number_of_arguments_is_passed(args):
 def test_that_base_validator_does_not_raise():
     with no_raise():
         Validator()(None, None)
+
+
+def test_multiple_of_rounding():
+    validator = MultipleOf(0.0001)
+    with no_raise():
+        validator(0.0075, None)


### PR DESCRIPTION
### Added
* Added support for boolean schemas.

### Changed
* Parsing schemas wih unsupported keywords now raises a
  `FeatureNotImplementedError`.

### Fixed
* Fixed bug causing some subschemas in `oneOf` and `anyOf` statements
  to be skipped.
* Fixed bug in `MultipleOf` due to floating point errors.


# Check list

## Before asking for a review

- [x] Target branch is `master`
- [x] `make test` passes locally.
- [x] [`[Unreleased]`](../blob/master/CHANGELOG.md#unreleased) section in [CHANGELOG.md](../blob/master/CHANGELOG.md) is updated.
- [x] I reviewed the "Files changed" tab and self-annotated anything unexpected.

## Before review (reviewer)

- [ ] All of the above are checked and true. **Review ALL items.** If not, return the PR to the author.
- [ ] Continuous Integration is passing. If not, return the PR to the author.

## After merge (reviewer)

- [ ] Any issues that may now be closed are closed.