### PR TITLE
Feature/not keyword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Types of changes are:
 * **Fixed** for any bug fixes.
 
 ## [Unreleased]
+### Added
+* Added support for `not` keyword.
 
 ## [0.5.0] - 2020-03-30
 ### Added

--- a/statham/dsl/constants.py
+++ b/statham/dsl/constants.py
@@ -31,7 +31,7 @@ T = TypeVar("T")
 Maybe = Union[T, NotPassed]
 
 
-COMPOSITION_KEYWORDS = ("anyOf", "oneOf", "allOf")
+COMPOSITION_KEYWORDS = ("anyOf", "oneOf", "allOf", "not")
 
 
 UNSUPPORTED_SCHEMA_KEYWORDS = {
@@ -46,7 +46,6 @@ UNSUPPORTED_SCHEMA_KEYWORDS = {
     "else",
     "maxProperties",
     "minProperties",
-    "not",
     "patternProperties",
     "propertyNames",
     "unevaluatedItems",

--- a/statham/dsl/elements/__init__.py
+++ b/statham/dsl/elements/__init__.py
@@ -5,6 +5,7 @@ from statham.dsl.elements.composition import (
     AllOf,
     AnyOf,
     CompositionElement,
+    Not,
     OneOf,
 )
 from statham.dsl.elements.meta import ObjectOptions

--- a/statham/dsl/elements/composition.py
+++ b/statham/dsl/elements/composition.py
@@ -20,6 +20,28 @@ def _dedupe(seq: Iterable[T]) -> List[T]:
     return [x for x in seq if not (x in seen or seen_add(x))]
 
 
+class Not(Element[T]):
+    """JSONSchema "not" element.
+
+    Element fails to validate if enclosed schema validates.
+    """
+
+    def __init__(self, element: Element, default: Any = NotPassed()):
+        self.element = element
+        super().__init__(default=default)
+
+    def construct(self, value: Any, property_: _Property):
+        if value is NotPassed():
+            return value
+        try:
+            _ = self.element(value, property_)
+        except (TypeError, ValidationError):
+            return value
+        raise ValidationError.from_validator(
+            property_, value, f"Must not match {self.element}."
+        )
+
+
 class CompositionElement(Element):
     """Composition Base Element.
 

--- a/tests/dsl/parser/test_parse_composition.py
+++ b/tests/dsl/parser/test_parse_composition.py
@@ -8,6 +8,7 @@ from statham.dsl.elements import (
     Array,
     Element,
     Integer,
+    Not,
     Number,
     Object,
     OneOf,
@@ -28,6 +29,12 @@ def test_parse_composition_with_empty_list(keyword):
 @pytest.mark.parametrize(
     "schema,expected",
     [
+        pytest.param({"not": {}}, Not(Element()), id="not-with-blank-element"),
+        pytest.param(
+            {"not": {"type": "string"}},
+            Not(String()),
+            id="not-with-typed-element",
+        ),
         pytest.param(
             {"anyOf": [{"type": "string"}]},
             String(),
@@ -163,12 +170,14 @@ def test_parse_composition_with_empty_list(keyword):
                 "oneOf": [{"minimum": 3}, {"maximum": 5}],
                 "anyOf": [{"type": "number"}, {"type": "integer"}],
                 "allOf": [{"minimum": 0}, {"maximum": 10}],
+                "not": {"multipleOf": 2},
             },
             AllOf(
                 Element(minimum=0),
                 Element(maximum=10),
                 OneOf(Element(minimum=3), Element(maximum=5)),
                 AnyOf(Number(), Integer()),
+                Not(Element(multipleOf=2)),
             ),
             id="all-compositions-no-outer",
         ),
@@ -178,6 +187,7 @@ def test_parse_composition_with_empty_list(keyword):
                 "oneOf": [{"minimum": 3}, {"maximum": 5}],
                 "anyOf": [{"type": "number"}, {"type": "integer"}],
                 "allOf": [{"minimum": 0}, {"maximum": 10}],
+                "not": {"multipleOf": 2},
             },
             AllOf(
                 Element(maximum=7),
@@ -185,6 +195,7 @@ def test_parse_composition_with_empty_list(keyword):
                 Element(maximum=10),
                 OneOf(Element(minimum=3), Element(maximum=5)),
                 AnyOf(Number(), Integer()),
+                Not(Element(multipleOf=2)),
             ),
             id="all-compositions-with-outer",
         ),

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -13,6 +13,17 @@ from tests.helpers import no_raise
 NOT_IMPLEMENTED = ("optional", "definitions", "defs", "ref", "refRemote")
 
 
+def _add_titles(schema):
+    if not isinstance(schema, (dict, list)):
+        return schema
+    if isinstance(schema, list):
+        return [_add_titles(val) for val in schema]
+    return {
+        "title": "Title",
+        **{key: _add_titles(value) for key, value in schema.items()},
+    }
+
+
 def iter_files(filepath: str):
     if path.isdir(filepath):
         for subpath in os.listdir(filepath):
@@ -96,9 +107,7 @@ def _extract_tests(directory: str) -> Iterator[Param]:
 
 @pytest.mark.parametrize("param", _extract_tests(DIRECTORY), ids=str)
 def test_jsonschema_official_test(param: Param):
-    schema = param.schema
-    if isinstance(schema, dict):
-        schema = {**param.schema, "title": "Test"}
+    schema = _add_titles(param.schema)
     try:
         element = parse_element(schema)
     except FeatureNotImplementedError:

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -147,6 +147,7 @@ def test_parse_and_serialize_schema_with_composition_keywords():
             "any": {"anyOf": [{"type": "string"}, {"minLength": 3}]},
             "all": {"allOf": [{"type": "string"}, {"minLength": 3}]},
             "one": {"oneOf": [{"type": "string"}, {"minLength": 3}]},
+            "not": {"not": {"type": "string"}},
         },
     }
     # pylint: disable=line-too-long
@@ -158,6 +159,8 @@ def test_parse_and_serialize_schema_with_composition_keywords():
     all: Maybe[str] = Property(AllOf(String(), Element(minLength=3)))
 
     one: Maybe[Any] = Property(OneOf(String(), Element(minLength=3)))
+
+    _not: Maybe[Any] = Property(Not(String()), source='not')
 """
     )
 


### PR DESCRIPTION
Any related Github Issues?: #14  

### Added
* Added support for `not` keyword.

# Check list

## Before asking for a review

- [x] Target branch is `master`
- [x] `make test` passes locally.
- [x] [`[Unreleased]`](../blob/master/CHANGELOG.md#unreleased) section in [CHANGELOG.md](../blob/master/CHANGELOG.md) is updated.
- [x] I reviewed the "Files changed" tab and self-annotated anything unexpected.

## Before review (reviewer)

- [ ] All of the above are checked and true. **Review ALL items.** If not, return the PR to the author.
- [ ] Continuous Integration is passing. If not, return the PR to the author.

## After merge (reviewer)

- [ ] Any issues that may now be closed are closed.