### PR TITLE
Add support for uniqueItems keyword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Types of changes are:
 
 ## [Unreleased]
 ### Added
+* Added support for `uniqueItems` keyword.
 * Added support for `minProperties` and `maxProperties` keywords.
 
 ## [0.6.0] - 2020-04-03

--- a/README.md
+++ b/README.md
@@ -92,9 +92,10 @@ def _check_my_format(value: str) -> bool:
 - [x] `additionalItems` keyword
 - [x] `minProperties`, `maxProperties` keywords
 - [x] `patternProperties` keyword
+- [x] `uniqueItems` keyword
 - [ ] Built-in string format validation #6
 - [ ] Generic keywords: `enum` #8, `const` #9
-- [ ] Array keywords: `uniqueItems` #10, `contains`
+- [ ] `contains` keyword
 - [ ] Property dependencies
 - [ ] Schema dependencies
 - [ ] `propertyNames`

--- a/statham/.pylintrc
+++ b/statham/.pylintrc
@@ -234,7 +234,8 @@ good-names=i,
            exclusiveMaximum,
            multipleOf,
            minProperties,
-           maxProperties
+           maxProperties,
+           uniqueItems
 
 # Include a hint for the correct naming format with invalid-name
 include-naming-hint=no

--- a/statham/dsl/constants.py
+++ b/statham/dsl/constants.py
@@ -46,5 +46,4 @@ UNSUPPORTED_SCHEMA_KEYWORDS = {
     "propertyNames",
     "unevaluatedItems",
     "unevaluatedProperties",
-    "uniqueItems",
 }

--- a/statham/dsl/elements/array.py
+++ b/statham/dsl/elements/array.py
@@ -28,12 +28,14 @@ class Array(Element[List[Item]]):
         default: Maybe[List] = NotPassed(),
         minItems: Maybe[int] = NotPassed(),
         maxItems: Maybe[int] = NotPassed(),
+        uniqueItems: bool = False,
     ):
         self.items = items
         self.additionalItems = additionalItems
         self.default = default
         self.minItems = minItems
         self.maxItems = maxItems
+        self.uniqueItems = uniqueItems
 
     @property
     def annotation(self) -> str:

--- a/statham/dsl/elements/base.py
+++ b/statham/dsl/elements/base.py
@@ -43,6 +43,7 @@ class Element(Generic[T]):
         additionalItems: Union["Element", bool] = True,
         minItems: Maybe[int] = NotPassed(),
         maxItems: Maybe[int] = NotPassed(),
+        uniqueItems: bool = False,
         minimum: Maybe[Numeric] = NotPassed(),
         maximum: Maybe[Numeric] = NotPassed(),
         exclusiveMinimum: Maybe[Numeric] = NotPassed(),
@@ -64,6 +65,7 @@ class Element(Generic[T]):
         self.additionalItems = additionalItems
         self.minItems = minItems
         self.maxItems = maxItems
+        self.uniqueItems = uniqueItems
         self.minimum = minimum
         self.maximum = maximum
         self.exclusiveMinimum = exclusiveMinimum

--- a/statham/dsl/helpers.py
+++ b/statham/dsl/helpers.py
@@ -5,10 +5,8 @@ from typing import (
     Callable,
     Container,
     Dict,
-    Hashable,
     Iterable,
     List,
-    Set,
     Tuple,
     Type,
     TypeVar,
@@ -102,11 +100,11 @@ def expand(function):
     return lambda args: function(*args)
 
 
-SequenceItem = TypeVar("SequenceItem", bound=Hashable)
+SequenceItem = TypeVar("SequenceItem")
 
 
 def remove_duplicates(seq: Iterable[SequenceItem]) -> List[SequenceItem]:
     """Remove duplicates whilst preserving order."""
-    seen: Set[SequenceItem] = set()
-    seen_add = seen.add
+    seen: List[SequenceItem] = []
+    seen_add = seen.append
     return [x for x in seq if not (x in seen or seen_add(x))]

--- a/tests/dsl/elements/test_array.py
+++ b/tests/dsl/elements/test_array.py
@@ -88,6 +88,26 @@ class TestArrayValidation:
     ):
         assert_validation(Array(String(), maxItems=1), success, value)
 
+    @staticmethod
+    @pytest.mark.parametrize(
+        "success,value",
+        [
+            (True, NotPassed()),
+            (True, []),
+            (True, ["foo"]),
+            (True, ["foo", "bar"]),
+            (True, [True, 1]),
+            (False, [True, True]),
+            (False, ["foo", "foo"]),
+            (False, ["foo", "bar", "foo"]),
+            (False, "foo"),
+        ],
+    )
+    def test_validation_performs_with_unique_items_keyword(
+        success: bool, value: Any
+    ):
+        assert_validation(Array(Element(), uniqueItems=True), success, value)
+
 
 def test_array_default_keyword():
     element = Array(String(), default=[])

--- a/tests/dsl/elements/test_reprs.py
+++ b/tests/dsl/elements/test_reprs.py
@@ -40,6 +40,11 @@ class ObjectWrapper(Object):
         (Array(String()), "Array(String())"),
         (Array(String(), minItems=3), "Array(String(), minItems=3)"),
         (Array([String(), Integer()]), "Array([String(), Integer()])"),
+        (
+            Array(String(), uniqueItems=True),
+            "Array(String(), uniqueItems=True)",
+        ),
+        (Array(String(), uniqueItems=False), "Array(String())"),
         (Boolean(), "Boolean()"),
         (Boolean(default=True), "Boolean(default=True)"),
         (Integer(), "Integer()"),
@@ -64,6 +69,8 @@ class ObjectWrapper(Object):
             Element(additionalProperties=False),
             "Element(additionalProperties=False)",
         ),
+        (Element(uniqueItems=True), "Element(uniqueItems=True)"),
+        (Element(uniqueItems=False), "Element()"),
         (ObjectWrapper, "ObjectWrapper"),
         (StringWrapper, "StringWrapper"),
         (

--- a/tests/dsl/parser/test_parse_element.py
+++ b/tests/dsl/parser/test_parse_element.py
@@ -55,6 +55,7 @@ def test_parse_element_with_arguments():
         "minProperties": 1,
         "maxProperties": 3,
         "items": {"type": "string"},
+        "uniqueItems": True,
     }
     expected = Element(
         default="foo",
@@ -71,6 +72,7 @@ def test_parse_element_with_arguments():
         minProperties=1,
         maxProperties=3,
         items=String(),
+        uniqueItems=True,
     )
     assert parse_element(schema) == expected
 


### PR DESCRIPTION
Any related Github Issues?: #10 

### Added
* Added support for `uniqueItems` keyword.

# Check list

## Before asking for a review

- [x] Target branch is `master`
- [x] `make test` passes locally.
- [x] [`[Unreleased]`](../blob/master/CHANGELOG.md#unreleased) section in [CHANGELOG.md](../blob/master/CHANGELOG.md) is updated.
- [x] I reviewed the "Files changed" tab and self-annotated anything unexpected.

## Before review (reviewer)

- [ ] All of the above are checked and true. **Review ALL items.** If not, return the PR to the author.
- [ ] Continuous Integration is passing. If not, return the PR to the author.

## After merge (reviewer)

- [ ] Any issues that may now be closed are closed.