### PR TITLE
Add support for contains keyword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Types of changes are:
 
 ## [Unreleased]
 ### Added
+* Added support for `contains` keyword.
 * Added support for `const` keyword.
 * Added support for `propertyNames` keyword.
 * Added support for `uniqueItems` keyword.

--- a/README.md
+++ b/README.md
@@ -95,9 +95,9 @@ def _check_my_format(value: str) -> bool:
 - [x] `uniqueItems` keyword
 - [x] `propertyNames` keyword
 - [x] `const` keyword #9
+- [x] `contains` keyword
 - [ ] Built-in string format validation #6
 - [ ] `enum` keyword #8
-- [ ] `contains` keyword
 - [ ] Property dependencies
 - [ ] Schema dependencies
 - [ ] `if`, `then`, `else` keywords

--- a/statham/dsl/constants.py
+++ b/statham/dsl/constants.py
@@ -35,7 +35,6 @@ COMPOSITION_KEYWORDS = ("anyOf", "oneOf", "allOf", "not")
 
 
 UNSUPPORTED_SCHEMA_KEYWORDS = {
-    "contains",
     "$defs",
     "dependencies",
     "enum",

--- a/statham/dsl/elements/array.py
+++ b/statham/dsl/elements/array.py
@@ -9,12 +9,12 @@ from statham.dsl.validation import InstanceOf
 Item = TypeVar("Item")
 
 
+# pylint: disable=too-many-instance-attributes
 class Array(Element[List[Item]]):
     """JSONSchema array element.
 
     Requires schema element for "items" keyword as first positional
     argument. Supported validation keywords provided via keyword arguments.
-    # TODO: contains
     """
 
     items: Union[Element[Item], List[Element]]
@@ -29,6 +29,7 @@ class Array(Element[List[Item]]):
         minItems: Maybe[int] = NotPassed(),
         maxItems: Maybe[int] = NotPassed(),
         uniqueItems: bool = False,
+        contains: Maybe[Element] = NotPassed(),
     ):
         self.items = items
         self.default = default
@@ -37,6 +38,7 @@ class Array(Element[List[Item]]):
         self.minItems = minItems
         self.maxItems = maxItems
         self.uniqueItems = uniqueItems
+        self.contains = contains
 
     @property
     def annotation(self) -> str:

--- a/statham/dsl/elements/base.py
+++ b/statham/dsl/elements/base.py
@@ -43,6 +43,7 @@ class Element(Generic[T]):
         minItems: Maybe[int] = NotPassed(),
         maxItems: Maybe[int] = NotPassed(),
         uniqueItems: bool = False,
+        contains: Maybe["Element"] = NotPassed(),
         minimum: Maybe[Numeric] = NotPassed(),
         maximum: Maybe[Numeric] = NotPassed(),
         exclusiveMinimum: Maybe[Numeric] = NotPassed(),
@@ -67,6 +68,7 @@ class Element(Generic[T]):
         self.minItems = minItems
         self.maxItems = maxItems
         self.uniqueItems = uniqueItems
+        self.contains = contains
         self.minimum = minimum
         self.maximum = maximum
         self.exclusiveMinimum = exclusiveMinimum

--- a/statham/dsl/parser.py
+++ b/statham/dsl/parser.py
@@ -118,7 +118,9 @@ def parse_element(
     if "patternProperties" in schema:
         schema["patternProperties"] = parse_pattern_properties(schema, state)
     if "propertyNames" in schema:
-        schema["propertyNames"] = parse_property_names(schema, state)
+        schema["propertyNames"] = parse_element(schema["propertyNames"], state)
+    if "contains" in schema:
+        schema["contains"] = parse_element(schema["contains"], state)
     schema["additionalProperties"] = parse_additional_properties(schema, state)
     schema["additionalItems"] = parse_additional_items(schema, state)
     if set(COMPOSITION_KEYWORDS) & set(schema):
@@ -400,15 +402,6 @@ def parse_additional_items(
     If key is not present, defaults to `True`.
     """
     return parse_additional("additionalItems", schema, state)
-
-
-def parse_property_names(
-    schema: Dict[str, Any], state: ParseState = None
-) -> Element:
-    """Parse propertyNames from a schema element."""
-    state = state or ParseState()
-    property_names = schema["propertyNames"]
-    return parse_element(property_names, state)
 
 
 def parse_array(schema: Dict[str, Any], state: ParseState = None) -> Array:

--- a/statham/dsl/validation/__init__.py
+++ b/statham/dsl/validation/__init__.py
@@ -1,6 +1,12 @@
 from typing import Iterator, Type
 
-from statham.dsl.validation.array import AdditionalItems, MinItems, MaxItems
+from statham.dsl.validation.array import (
+    AdditionalItems,
+    Contains,
+    MinItems,
+    MaxItems,
+    UniqueItems,
+)
 from statham.dsl.validation.base import Const, InstanceOf, NoMatch, Validator
 from statham.dsl.validation.numeric import (
     Minimum,

--- a/statham/dsl/validation/array.py
+++ b/statham/dsl/validation/array.py
@@ -70,3 +70,18 @@ class UniqueItems(Validator):
             if len(remove_duplicates(aliased_value)) == length:
                 return
         raise ValidationError
+
+
+class Contains(Validator):
+    types = (list,)
+    keywords = ("contains",)
+    message = "Must contain one element matching {contains}."
+
+    def validate(self, value: Any):
+        for sub_value in value:
+            try:
+                _ = self.params["contains"](sub_value)
+                return
+            except (TypeError, ValidationError):
+                continue
+        raise ValidationError

--- a/tests/dsl/elements/test_array.py
+++ b/tests/dsl/elements/test_array.py
@@ -108,6 +108,25 @@ class TestArrayValidation:
     ):
         assert_validation(Array(Element(), uniqueItems=True), success, value)
 
+    @staticmethod
+    @pytest.mark.parametrize(
+        "success,value",
+        [
+            (True, NotPassed()),
+            (True, ["foo"]),
+            (True, ["foo", 1]),
+            (True, ["foo", 1, "bar"]),
+            (False, []),
+            (False, [True, True]),
+            (False, [1, 2, 3]),
+            (False, "foo"),
+        ],
+    )
+    def test_validation_performs_with_contains_keyword(
+        success: bool, value: Any
+    ):
+        assert_validation(Array(Element(), contains=String()), success, value)
+
 
 def test_array_default_keyword():
     element = Array(String(), default=[])

--- a/tests/dsl/elements/test_element.py
+++ b/tests/dsl/elements/test_element.py
@@ -163,6 +163,22 @@ CASES = [
         good=["foo", NotPassed()],
         bad=[None, True, 1, 1.2, "bar", {"foo": "bar"}, ["foo", 1]],
     ),
+    Case(
+        element=Element(contains=String()),
+        good=[
+            None,
+            NotPassed(),
+            True,
+            1,
+            1.2,
+            "foo",
+            {"foo": "bar"},
+            ["foo"],
+            ["foo", 1],
+            ["foo", 1, "bar"],
+        ],
+        bad=[[], [1, 2, 3]],
+    ),
 ]
 
 

--- a/tests/dsl/elements/test_reprs.py
+++ b/tests/dsl/elements/test_reprs.py
@@ -45,6 +45,10 @@ class ObjectWrapper(Object):
             "Array(String(), uniqueItems=True)",
         ),
         (Array(String(), uniqueItems=False), "Array(String())"),
+        (
+            Array(Element(), contains=String()),
+            "Array(Element(), contains=String())",
+        ),
         (Boolean(), "Boolean()"),
         (Boolean(default=True), "Boolean(default=True)"),
         (Integer(), "Integer()"),
@@ -76,6 +80,7 @@ class ObjectWrapper(Object):
             Element(propertyNames=String(maxLength=3)),
             "Element(propertyNames=String(maxLength=3))",
         ),
+        (Element(contains=String()), "Element(contains=String())"),
         (ObjectWrapper, "ObjectWrapper"),
         (StringWrapper, "StringWrapper"),
         (

--- a/tests/dsl/parser/test_parse_array.py
+++ b/tests/dsl/parser/test_parse_array.py
@@ -42,6 +42,16 @@ from statham.dsl.parser import parse_element
             ),
             id="with-tuple-items-and-keywords",
         ),
+        pytest.param(
+            {"type": "array", "uniqueItems": True},
+            Array(Element(), uniqueItems=True),
+            id="with-unique-items",
+        ),
+        pytest.param(
+            {"type": "array", "contains": {"type": "string"}},
+            Array(Element(), contains=String()),
+            id="with-contains",
+        ),
     ],
 )
 def test_parse_array_produces_expected_element(

--- a/tests/dsl/parser/test_parse_element.py
+++ b/tests/dsl/parser/test_parse_element.py
@@ -58,6 +58,7 @@ def test_parse_element_with_arguments():
         "items": {"type": "string"},
         "uniqueItems": True,
         "propertyNames": {"type": "string", "maxLength": 3},
+        "contains": {"type": "string"},
     }
     expected = Element(
         default="foo",
@@ -77,6 +78,7 @@ def test_parse_element_with_arguments():
         items=String(),
         uniqueItems=True,
         propertyNames=String(maxLength=3),
+        contains=String(),
     )
     assert parse_element(schema) == expected
 

--- a/tests/dsl/parser/test_parse_object.py
+++ b/tests/dsl/parser/test_parse_object.py
@@ -178,7 +178,6 @@ class ObjectWithConst(Object, const={"foo": "bar"}):
             },
             ObjectWithConst,
             id="with-const",
-            marks=pytest.mark.foo,
         ),
     ],
 )

--- a/tests/dsl/test_comparators.py
+++ b/tests/dsl/test_comparators.py
@@ -1,6 +1,6 @@
 import pytest
 
-from statham.dsl.elements import String, Object, Array
+from statham.dsl.elements import Array, Element, Object, String
 from statham.dsl.property import Property
 
 
@@ -48,6 +48,10 @@ class Doo(Object, const={"value": "foo"}):
         (Array(String()), Array(String())),
         (Array(String(), minItems=3), Array(String(), minItems=3)),
         (Array(String(minLength=3)), Array(String(minLength=3))),
+        (
+            Array(Element(), contains=String()),
+            Array(Element(), contains=String()),
+        ),
         (Foo, Bar),
         (Raz, Maz),
     ],
@@ -62,6 +66,7 @@ def test_equivalent_schemas_are_equal(left, right):
         (String(), String(default="foo")),
         (Array(String()), Array(String(), minItems=3)),
         (Array(String()), Array(String(minLength=3))),
+        (Array(Element()), Array(Element(), contains=String())),
         (Foo, Baz),
         (Foo, Mux),
         (Foo, Qux),


### PR DESCRIPTION
### Added
* Added support for `contains` keyword.

# Check list

## Before asking for a review

- [x] Target branch is `master`
- [x] `make test` passes locally.
- [x] [`[Unreleased]`](../blob/master/CHANGELOG.md#unreleased) section in [CHANGELOG.md](../blob/master/CHANGELOG.md) is updated.
- [x] I reviewed the "Files changed" tab and self-annotated anything unexpected.

## Before review (reviewer)

- [ ] All of the above are checked and true. **Review ALL items.** If not, return the PR to the author.
- [ ] Continuous Integration is passing. If not, return the PR to the author.

## After merge (reviewer)

- [ ] Any issues that may now be closed are closed.