### PR TITLE
Add an inline constructor for Object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Types of changes are:
 * Added support for `required` keyword class argument to `Object`
   subclasses.
 * Added support for `Object` model inheritance.
+* Added inline constructor for `Object` DSL elements, `Object.inline`
 
 ### Changed
 * Setting properties dynamically now automatically binds them.

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -56,6 +56,8 @@ Typed schemas are declared using the following subclasses of :class:`statham.dsl
 
 .. autoclass:: statham.dsl.elements.Object
 
+    .. automethod:: inline
+
 .. autoclass:: statham.dsl.elements.String
 
 

--- a/docs/source/dsl.rst
+++ b/docs/source/dsl.rst
@@ -152,6 +152,14 @@ Properties which are accepted via ``additionalProperties`` or ``patternPropertie
 >>> value["other"]
 "another string"
 
+:class:`~statham.dsl.elements.Object` elements may also be declared via an inline constructor as follows:
+
+>>> StringWrapper = Object.inline("StringWrapper", properties={"value": Property(String())})
+>>> StringWrapper({"value": "a string"})
+StringWrapper(value='a string')
+
+However, elements declared this way will not have the same type hinting support as those declared using class notation.
+
 .. note::
 
     It is possible to pass ``"object"`` values to :class:`~statham.dsl.elements.Element`. Assuming all validation passes, the return value will be a instance of a ``dict`` subclass allowing attribute access to its keys. This allows a consistent interface with :class:`~statham.dsl.elements.Object` instances.

--- a/statham/dsl/elements/object.py
+++ b/statham/dsl/elements/object.py
@@ -1,7 +1,7 @@
 from typing import Any, ClassVar, Dict, Union
 
 from statham.dsl.elements.base import Element, UNBOUND_PROPERTY
-from statham.dsl.elements.meta import ObjectMeta
+from statham.dsl.elements.meta import ObjectClassDict, ObjectMeta
 from statham.dsl.exceptions import ValidationError
 from statham.dsl.property import _Property
 from statham.dsl.constants import NotPassed
@@ -105,3 +105,25 @@ class Object(metaclass=ObjectMeta):
 
     def __getitem__(self, key: str) -> Any:
         return self._dict[key]
+
+    @staticmethod
+    def inline(
+        name: str, *, properties: Dict[str, Any] = None, **kwargs
+    ) -> ObjectMeta:
+        """Inline constructor for object schema elements.
+
+        Useful for minor objects, at the cost of reduced type checking
+        support.
+
+        :param name: The name of the schema element.
+        :param properties: Dictionary of properties accepted by the schema
+            element.
+        :param kwargs: Any accepted class args to `Object` subclasses.
+        :return: A new subclass of `Object` with the appropriate validation
+            rules.
+        """
+        properties = properties or {}
+        object_properties = ObjectClassDict()
+        for prop_name, prop in properties.items():
+            object_properties[prop_name] = prop
+        return ObjectMeta(name, (Object,), object_properties, **kwargs)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ def pytest_assertrepr_compare(op, left, right):
         pubvars = lambda obj: sorted(
             f"  {key}={repr(value)}"
             for key, value in vars(obj).items()
-            if not key.startswith("_")
+            if not key.startswith("_") or key == "_properties"
         )
         return [
             "Comparing ObjectMeta instances:",

--- a/tests/dsl/test_comparators.py
+++ b/tests/dsl/test_comparators.py
@@ -40,6 +40,13 @@ class Doo(Object, const={"value": "foo"}):
     value = Property(String())
 
 
+InlineFoo = Object.inline("InlineFoo", properties={"value": Property(String())})
+InlineBar = Object.inline("InlineBar", properties={"value": Property(String())})
+InlineBaz = Object.inline(
+    "InlineBaz", properties={"value": Property(String(), required=True)}
+)
+
+
 @pytest.mark.parametrize(
     "left,right",
     [
@@ -54,6 +61,9 @@ class Doo(Object, const={"value": "foo"}):
         ),
         (Foo, Bar),
         (Raz, Maz),
+        (Foo, InlineFoo),
+        (InlineFoo, InlineBar),
+        (Baz, InlineBaz),
     ],
 )
 def test_equivalent_schemas_are_equal(left, right):
@@ -73,6 +83,9 @@ def test_equivalent_schemas_are_equal(left, right):
         (Foo, Raz),
         (Foo, Taz),
         (Foo, Doo),
+        (Foo, InlineBaz),
+        (InlineFoo, Baz),
+        (InlineFoo, InlineBaz),
     ],
 )
 def test_non_equivalent_schemas_are_not_equal(left, right):


### PR DESCRIPTION

* Added inline constructor for `Object` DSL elements, `Object.inline`

# Check list

## Before asking for a review

- [x] Target branch is `master`
- [x] `make test` passes locally.
- [x] [`[Unreleased]`](../blob/master/CHANGELOG.md#unreleased) section in [CHANGELOG.md](../blob/master/CHANGELOG.md) is updated.
- [x] I reviewed the "Files changed" tab and self-annotated anything unexpected.

## Before review (reviewer)

- [ ] All of the above are checked and true. **Review ALL items.** If not, return the PR to the author.
- [ ] Continuous Integration is passing. If not, return the PR to the author.

## After merge (reviewer)

- [ ] Any issues that may now be closed are closed.