### PR TITLE
Bugfix/title special characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Types of changes are:
 
 ### Fixed
 * Fixed a typo in property validation error messages.
+* Fixed a bug where special characters were improperly handled in
+  `"object"` type schema parsing.
 
 ## [0.12.0] - 2020-10-03
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Types of changes are:
 ### Fixed
 * Fixed a typo in property validation error messages.
 * Fixed a bug where special characters were improperly handled in
-  `"object"` type schema parsing.
+  `"object"` type schema parsing ([#77](https://github.com/jacksmith15/statham-schema/issues/77)).
 
 ## [0.12.0] - 2020-10-03
 ### Changed

--- a/statham/schema/parser.py
+++ b/statham/schema/parser.py
@@ -520,7 +520,7 @@ def _keyword_filter(type_: Type) -> Callable[[Dict[str, Any]], Dict[str, Any]]:
 
 def _title_format(name: str) -> str:
     """Convert titles in schemas to class names."""
-    words = list(filter(None, re.split(r"[ _-]", name)))
+    words = list(filter(None, re.split("[^a-zA-Z0-9]", name)))
     segments = chain.from_iterable(
         [
             re.findall("[A-Z][^A-Z]*", word[0].upper() + word[1:])

--- a/tests/component/test_bad_titles.py
+++ b/tests/component/test_bad_titles.py
@@ -1,0 +1,5 @@
+from tests.models.bad_titles import MyTestJSONSchema
+
+
+def test_schema_has_expected_title():
+    assert MyTestJSONSchema.__name__ == "MyTestJSONSchema"

--- a/tests/jsonschemas/bad_titles.json
+++ b/tests/jsonschemas/bad_titles.json
@@ -1,0 +1,7 @@
+{
+    "title": "My Test JSON Schema!",
+    "type": "object",
+    "properties": {
+        "id": {"type": "integer"}
+    }
+}

--- a/tests/models/bad_titles.py
+++ b/tests/models/bad_titles.py
@@ -1,0 +1,8 @@
+from statham.schema.constants import Maybe
+from statham.schema.elements import Integer, Object
+from statham.schema.property import Property
+
+
+class MyTestJSONSchema(Object):
+
+    id: Maybe[int] = Property(Integer())

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -26,6 +26,12 @@ from statham.schema.parser import _title_format
         ("Foo-Bar", "FooBar"),
         ("foo-Bar", "FooBar"),
         ("Foo-bar", "FooBar"),
+        ("FooBar!", "FooBar"),
+        ("Foo Bar!", "FooBar"),
+        ("Foo+bar", "FooBar"),
+        ("Foo+-bar", "FooBar"),
+        ("+Foo-bar", "FooBar"),
+        ("Foo,bar", "FooBar"),
     ],
 )
 def test_title_format_produces_expected_output(title: str, expected: str):


### PR DESCRIPTION
Any related Github Issues?: [#77](https://github.com/jacksmith15/statham-schema/issues/77)

* Fixed a bug where special characters were improperly handled in
  `"object"` type schema parsing ([#77](https://github.com/jacksmith15/statham-schema/issues/77)).

# Check list

## Before asking for a review

- [x] Target branch is `master`
- [x] `make test` passes locally.
- [x] [`[Unreleased]`](../blob/master/CHANGELOG.md#unreleased) section in [CHANGELOG.md](../blob/master/CHANGELOG.md) is updated.
- [x] I reviewed the "Files changed" tab and self-annotated anything unexpected.

## Before review (reviewer)

- [ ] All of the above are checked and true. **Review ALL items.** If not, return the PR to the author.
- [ ] Continuous Integration is passing. If not, return the PR to the author.

## After merge (reviewer)

- [ ] Any issues that may now be closed are closed.